### PR TITLE
adding braille image discryptions for different items:

### DIFF
--- a/src/eapi/NVDA.rb
+++ b/src/eapi/NVDA.rb
@@ -178,6 +178,17 @@ module NVDA
         end
         text.gsub!(/\004INFNEW\{([^\}]+)\}\004/) { "[#{$1}]" }
         text.gsub!("\004NEW\004", "[]")
+        text.gsub!("\004ATTACHMENT\004", "⣏⣹")
+        text.gsub!("\004PINNED\004", "⡠⠊⠑⢄")
+        text.gsub!("\004ONLINE\004", "(online: ")
+        text.gsub!("\004CLOSED\004", "⣏⣹⠉⢹")
+        text.gsub!("\004RESTRICTED\004", "(*)")
+        text.gsub!("\004SPONSOR\004", "(sponsor!)")
+        text.gsub!("\004CONTAINING\004", "->")
+        text.gsub!("\004LIKED\004", "(like)")
+
+
+
         text.gsub!(/\004[^\004]+\004/, "")
         realtext = text
       end

--- a/src/eapi/UI.rb
+++ b/src/eapi/UI.rb
@@ -36,6 +36,13 @@ module EltenAPI
         if sound != nil
           stream = Bass::BASS_StreamCreateFile.call(1, sound, 0, 0, sound.bytesize, 0, 262144)
           Bass::BASS_ChannelSetAttribute.call(stream, 2, [volume.to_f / 100.0 * 0.5].pack("f").unpack("I")[0])
+          if pitch != 100
+            f = [0].pack("f")
+            Bass::BASS_ChannelGetAttribute.call(stream, 1, f)
+            frq = f.unpack("f").first
+            freq = frq * pitch / 100.0
+            Bass::BASS_ChannelSetAttribute.call(stream, 1, [freq.to_f].pack("f").unpack("I")[0])
+          end
           if Configuration.usepan == 1
             Bass::BASS_ChannelSetAttribute.call(stream, 3, [pan.to_f / 50.0 - 1.0].pack("f").unpack("I")[0])
           end


### PR DESCRIPTION
e.g. if a message have an attachment, the braille display will show an attachment sign. this is made for many things: user online, sponsor, pinned thread, attachment, closed thread or forum, item that has items in it... and more.
contributed by bomberman29@elten.me