### PR TITLE
Added an initial Japanese translation

### DIFF
--- a/locale/ja-JP/LC_MESSAGES/ja.po
+++ b/locale/ja-JP/LC_MESSAGES/ja.po
@@ -1,0 +1,12056 @@
+# Elten Japanese Translation.
+# Copyright (C) 2024 "Dawid Pieper"
+# This file is distributed under the same license as the Elten package.
+# FIRST AUTHOR <garrettsworld2000@gmail.com>, 2024.
+# En: Please note: This translation was created using a combination of Chat GPT O1's advanced reasoning model and the DeepL next generation language model. I cannot guarantee the translation quality will be perfect. If you find errors, please submit an issue or a pull request.
+# JP: ご注意ください：この翻訳は、Chat GPT O1の高度な推論モデルとDeepL次世代言語モデルを組み合わせて作成されています。翻訳の品質が完璧であることを保証することはできません。エラーを見つけた場合は、問題またはプルリクエストを提出してください。
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Elten 2.5\n"
+"Report-Msgid-Bugs-To: dawidpieper@o2.pl\n"
+"POT-Creation-Date: 2024-01-20 23:12+0100\n"
+"PO-Revision-Date: 2024-09-27 00:43-0400\n"
+"Last-Translator: Garrett Brown\n"
+"Language-Team: dangero2000\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.5\n"
+
+#: ../agent/eprocessor.rb:99
+msgctxt "Conference"
+msgid "Speech allowed"
+msgstr "発言が許可した"
+
+#: ../agent/eprocessor.rb:102
+msgctxt "Conference"
+msgid "Speech denied"
+msgstr "発言が禁止した"
+
+#: ../agent/eprocessor.rb:150 ../src/EAPI/Conference.rb:47
+msgctxt "Conference_cards"
+msgid "hearts"
+msgstr "ハート"
+
+#: ../agent/eprocessor.rb:152 ../src/EAPI/Conference.rb:49
+msgctxt "Conference_cards"
+msgid "spades"
+msgstr "スペード"
+
+#: ../agent/eprocessor.rb:154 ../src/EAPI/Conference.rb:51
+msgctxt "Conference_cards"
+msgid "clubs"
+msgstr "クラブ"
+
+#: ../agent/eprocessor.rb:156 ../src/EAPI/Conference.rb:53
+msgctxt "Conference_cards"
+msgid "diamonds"
+msgstr "ダイヤ"
+
+#: ../agent/eprocessor.rb:158 ../src/EAPI/Conference.rb:55
+msgctxt "Conference_cards"
+msgid "red"
+msgstr "赤"
+
+#: ../agent/eprocessor.rb:160 ../src/EAPI/Conference.rb:57
+msgctxt "Conference_cards"
+msgid "green"
+msgstr "緑"
+
+#: ../agent/eprocessor.rb:162 ../src/EAPI/Conference.rb:59
+msgctxt "Conference_cards"
+msgid "blue"
+msgstr "青"
+
+#: ../agent/eprocessor.rb:164 ../src/EAPI/Conference.rb:61
+msgctxt "Conference_cards"
+msgid "yellow"
+msgstr "黄"
+
+#: ../agent/eprocessor.rb:171 ../src/EAPI/Conference.rb:71
+msgctxt "Conference_cards"
+msgid "two"
+msgstr "２"
+
+#: ../agent/eprocessor.rb:173 ../src/EAPI/Conference.rb:73
+msgctxt "Conference_cards"
+msgid "three"
+msgstr "３"
+
+#: ../agent/eprocessor.rb:175 ../src/EAPI/Conference.rb:75
+msgctxt "Conference_cards"
+msgid "four"
+msgstr "４"
+
+#: ../agent/eprocessor.rb:177 ../src/EAPI/Conference.rb:77
+msgctxt "Conference_cards"
+msgid "five"
+msgstr "５"
+
+#: ../agent/eprocessor.rb:179 ../src/EAPI/Conference.rb:79
+msgctxt "Conference_cards"
+msgid "six"
+msgstr "6"
+
+#: ../agent/eprocessor.rb:181 ../src/EAPI/Conference.rb:81
+msgctxt "Conference_cards"
+msgid "seven"
+msgstr "7"
+
+#: ../agent/eprocessor.rb:183 ../src/EAPI/Conference.rb:83
+msgctxt "Conference_cards"
+msgid "eight"
+msgstr "8"
+
+#: ../agent/eprocessor.rb:185 ../src/EAPI/Conference.rb:85
+msgctxt "Conference_cards"
+msgid "nine"
+msgstr "9"
+
+#: ../agent/eprocessor.rb:187 ../src/EAPI/Conference.rb:87
+msgctxt "Conference_cards"
+msgid "ten"
+msgstr "10"
+
+#: ../agent/eprocessor.rb:189 ../src/EAPI/Conference.rb:89
+msgctxt "Conference_cards"
+msgid "jack"
+msgstr "ジャック"
+
+#: ../agent/eprocessor.rb:191 ../src/EAPI/Conference.rb:91
+msgctxt "Conference_cards"
+msgid "queen"
+msgstr "クイーン"
+
+#: ../agent/eprocessor.rb:193 ../src/EAPI/Conference.rb:93
+msgctxt "Conference_cards"
+msgid "king"
+msgstr "キング"
+
+#: ../agent/eprocessor.rb:195 ../src/EAPI/Conference.rb:95
+msgctxt "Conference_cards"
+msgid "ace"
+msgstr "エース"
+
+#: ../agent/eprocessor.rb:197 ../src/EAPI/Conference.rb:97
+msgctxt "Conference_cards"
+msgid "joker"
+msgstr "ジョーカー"
+
+#: ../agent/eprocessor.rb:208 ../agent/eprocessor.rb:210 ../src/EAPI/Conference.rb:108 ../src/EAPI/Conference.rb:110
+msgctxt "Conference_cards"
+msgid "Skip"
+msgstr "スキップ"
+
+#: ../agent/eprocessor.rb:212 ../agent/eprocessor.rb:214 ../src/EAPI/Conference.rb:112 ../src/EAPI/Conference.rb:114
+msgctxt "Conference_cards"
+msgid "Draw two"
+msgstr "2枚引く"
+
+#: ../agent/eprocessor.rb:216 ../agent/eprocessor.rb:218 ../src/EAPI/Conference.rb:116 ../src/EAPI/Conference.rb:118
+msgctxt "Conference_cards"
+msgid "Reverse"
+msgstr "リバース"
+
+#: ../agent/eprocessor.rb:223 ../src/EAPI/Conference.rb:124 ../src/EAPI/Conference.rb:126 ../src/EAPI/Conference.rb:128 ../src/EAPI/Conference.rb:130
+msgctxt "Conference_cards"
+msgid "Wild"
+msgstr "ワイルド"
+
+#: ../agent/eprocessor.rb:225 ../src/EAPI/Conference.rb:132 ../src/EAPI/Conference.rb:134 ../src/EAPI/Conference.rb:136 ../src/EAPI/Conference.rb:138
+msgctxt "Conference_cards"
+msgid "Wild draw four"
+msgstr "ワイルド4枚引く"
+
+#: ../agent/eprocessor.rb:235 ../src/EAPI/Conference.rb:149
+msgctxt "Conference_cards"
+msgid "%{card} of %{colour}"
+msgstr "%{colour}の%{card}"
+
+#: ../agent/eprocessor.rb:241 ../src/EAPI/Conference.rb:155
+msgctxt "Conference_cards"
+msgid "%{colour} %{card}"
+msgstr "%{colour}%{card}"
+
+#: ../agent/quicknav.rb:97 ../src/scenes/Messages.rb:139
+msgctxt "Messages"
+msgid "Messages"
+msgstr "メッセージ"
+
+#: ../agent/quicknav.rb:99 ../src/Scenes/FeedViewer.rb:69
+msgctxt "FeedViewer"
+msgid "Feed"
+msgstr "フィード"
+
+#: ../agent/quicknav.rb:101 ../src/Scenes/Conference.rb:176 ../src/Scenes/Conference.rb:283
+msgctxt "Conference"
+msgid "Conference"
+msgstr "会議"
+
+#: ../agent/quicknav.rb:136 ../src/scenes/Messages.rb:245
+msgctxt "Messages"
+msgid "Send a new message"
+msgstr "新しいメッセージを送信"
+
+#: ../agent/quicknav.rb:137 ../agent/quicknav.rb:278 ../agent/quicknav.rb:465 ../src/scenes/Messages.rb:693 ../src/scenes/Messages.rb:960
+msgctxt "Messages"
+msgid "Send"
+msgstr "送信"
+
+#: ../agent/quicknav.rb:137 ../src/scenes/Messages.rb:866
+msgctxt "Messages"
+msgid "Message:"
+msgstr "メッセージ："
+
+#: ../agent/quicknav.rb:137 ../src/scenes/Messages.rb:865
+msgctxt "Messages"
+msgid "Subject:"
+msgstr "件名："
+
+#: ../agent/quicknav.rb:137 ../agent/quicknav.rb:278 ../agent/quicknav.rb:465 ../src/Scenes/Conference.rb:799 ../src/Scenes/Conference.rb:857 ../src/Scenes/Conference.rb:885 ../src/Scenes/Conference.rb:959 ../src/Scenes/Conference.rb:1075
+#: ../src/Scenes/Conference.rb:1148 ../src/Scenes/Conference.rb:1288 ../src/Scenes/Conference.rb:1785 ../src/Scenes/Conference.rb:1817 ../src/Scenes/Conference.rb:1854 ../src/Scenes/Conference.rb:1956 ../src/Scenes/Conference.rb:1977 ../src/Scenes/Conference.rb:2002
+#: ../src/Scenes/Conference.rb:2258 ../src/eapi/Common.rb:16 ../src/eapi/Common.rb:1230 ../src/eapi/Controls.rb:965 ../src/eapi/Controls.rb:1066 ../src/eapi/Controls.rb:3328 ../src/eapi/Controls.rb:3394 ../src/eapi/Controls.rb:4347 ../src/eapi/Controls.rb:4425
+#: ../src/eapi/Controls.rb:4488 ../src/eapi/Controls.rb:4641 ../src/eapi/External.rb:120 ../src/eapi/UI.rb:783 ../src/scenes/Account.rb:117 ../src/scenes/Account.rb:702 ../src/scenes/Ban.rb:26 ../src/scenes/Ban.rb:113 ../src/scenes/Blog.rb:513
+#: ../src/scenes/Blog.rb:1049 ../src/scenes/Blog.rb:1251 ../src/scenes/Blog.rb:1389 ../src/scenes/Blog.rb:1443 ../src/scenes/Blog.rb:1565 ../src/scenes/Blog.rb:1961 ../src/scenes/Blog.rb:2413 ../src/scenes/Blog.rb:2542 ../src/scenes/Clock.rb:12
+#: ../src/scenes/Clock.rb:70 ../src/scenes/Forum.rb:738 ../src/scenes/Forum.rb:764 ../src/scenes/Forum.rb:910 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:1305 ../src/scenes/Forum.rb:1465 ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+#: ../src/scenes/Forum.rb:2307 ../src/scenes/Forum.rb:2372 ../src/scenes/Forum.rb:2472 ../src/scenes/Forum.rb:3646 ../src/scenes/Forum.rb:3697 ../src/scenes/Forum.rb:3814 ../src/scenes/Forum.rb:3839 ../src/scenes/Forum.rb:4352 ../src/scenes/Honors.rb:186
+#: ../src/scenes/Honors.rb:222 ../src/scenes/Honors.rb:303 ../src/scenes/Install.rb:3 ../src/scenes/Login.rb:88 ../src/scenes/Main.rb:247 ../src/scenes/Messages.rb:290 ../src/scenes/Messages.rb:871 ../src/scenes/Notes.rb:118 ../src/scenes/Notes.rb:252
+#: ../src/scenes/Polls.rb:182 ../src/scenes/Polls.rb:240 ../src/scenes/Polls.rb:416 ../src/scenes/Portable.rb:9 ../src/scenes/Settings.rb:119 ../src/scenes/Sounds.rb:237 ../src/scenes/SpeedTest.rb:9
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: ../agent/quicknav.rb:137 ../src/scenes/Messages.rb:863
+msgctxt "Messages"
+msgid "Recipient"
+msgstr "受信者"
+
+#: ../agent/quicknav.rb:162 ../agent/quicknav.rb:166 ../agent/quicknav.rb:302 ../agent/quicknav.rb:306 ../src/scenes/Messages.rb:705
+msgctxt "Messages"
+msgid "Failed to send message"
+msgstr "メッセージの送信に失敗しました"
+
+#: ../agent/quicknav.rb:220 ../agent/quicknav.rb:222 ../src/scenes/Messages.rb:803
+msgctxt "Messages"
+msgid "To"
+msgstr "宛先"
+
+#: ../agent/quicknav.rb:277 ../src/scenes/Main.rb:409
+msgctxt "Main"
+msgid "Publish to a feed"
+msgstr "フィードに投稿"
+
+#: ../agent/quicknav.rb:278 ../agent/quicknav.rb:465 ../src/scenes/Main.rb:414
+msgctxt "Main"
+msgid "Message"
+msgstr "メッセージ"
+
+#: ../agent/quicknav.rb:318 ../src/Scenes/Conference.rb:1225
+msgctxt "Conference"
+msgid "Unmute microphone"
+msgstr "マイクのミュートを解除"
+
+#: ../agent/quicknav.rb:318 ../src/Scenes/Conference.rb:1224
+msgctxt "Conference"
+msgid "Mute microphone"
+msgstr "マイクをミュート"
+
+#: ../agent/quicknav.rb:321 ../src/Scenes/Conference.rb:1229
+msgctxt "Conference"
+msgid "Microphone muted"
+msgstr "マイクがミュートしました"
+
+#: ../agent/quicknav.rb:323 ../src/Scenes/Conference.rb:1231
+msgctxt "Conference"
+msgid "Microphone unmuted"
+msgstr "マイクのミュートを解除しました"
+
+#: ../agent/quicknav.rb:326 ../src/Scenes/Conference.rb:1274
+msgctxt "Conference"
+msgid "Roll a 6-sided dice"
+msgstr "6面ダイスを振る"
+
+#: ../agent/quicknav.rb:329 ../src/Scenes/Conference.rb:1275
+msgctxt "Conference"
+msgid "Roll a custom dice"
+msgstr "カスタムダイスを振る"
+
+#: ../agent/quicknav.rb:331 ../src/Scenes/Conference.rb:1608
+msgctxt "Conference"
+msgid "Which dice do you want to roll?"
+msgstr "どのダイスを振りますか？"
+
+#: ../agent/quicknav.rb:335 ../src/Scenes/Conference.rb:1608
+msgctxt "Conference"
+msgid "%{count}-sided"
+msgstr "%{count}面"
+
+#: ../agent/quicknav.rb:347 ../src/Scenes/Conference.rb:1117
+msgctxt "Conference"
+msgid "Stream audio file"
+msgstr "オーディオファイルをストリームする"
+
+#: ../agent/quicknav.rb:348 ../src/Scenes/Conference.rb:806 ../src/Scenes/Conference.rb:1120
+msgctxt "Conference"
+msgid "Select audio file"
+msgstr "オーディオファイルを選択"
+
+#: ../agent/quicknav.rb:353 ../src/Scenes/Conference.rb:1101
+msgctxt "Conference"
+msgid "Remove audio stream"
+msgstr "オーディオストリームを削除"
+
+#: ../agent/quicknav.rb:358 ../src/Scenes/Conference.rb:1256
+msgctxt "Conference"
+msgid "Disable push to talk"
+msgstr "プッシュトゥトークを無効にする"
+
+#: ../agent/quicknav.rb:358 ../src/Scenes/Conference.rb:1255
+msgctxt "Conference"
+msgid "Enable push to talk"
+msgstr "プッシュトゥトークを有効にする"
+
+#: ../agent/quicknav.rb:362
+msgctxt "Conference"
+msgid "Show chat history"
+msgstr "チャット履歴を表示"
+
+#: ../agent/quicknav.rb:363
+msgctxt "Conference"
+msgid "Chat"
+msgstr "チャット"
+
+#: ../agent/quicknav.rb:373
+msgctxt "Conference"
+msgid "Post in chat"
+msgstr "チャットに投稿"
+
+#: ../agent/quicknav.rb:387 ../src/Scenes/Conference.rb:130
+msgctxt "Conference"
+msgid "Whisper"
+msgstr "ささやく"
+
+#: ../agent/quicknav.rb:389
+msgctxt "Conference"
+msgid "End whispering"
+msgstr "ささやきを終了"
+
+#: ../agent/quicknav.rb:400 ../src/Scenes/Conference.rb:86
+msgctxt "Conference"
+msgid "Mute user"
+msgstr "ユーザーをミュート"
+
+#: ../agent/quicknav.rb:402 ../src/Scenes/Conference.rb:87
+msgctxt "Conference"
+msgid "Unmute user"
+msgstr "ユーザーのミュートを解除"
+
+#: ../agent/quicknav.rb:411 ../src/Scenes/Conference.rb:126
+msgctxt "Conference"
+msgid "Go to user"
+msgstr "ユーザーに移動"
+
+#: ../agent/quicknav.rb:464 ../src/Scenes/Conference.rb:42
+msgctxt "Conference"
+msgid "Chat message"
+msgstr "チャットメッセージ"
+
+#: ../agent/quicknav.rb:509 ../src/scenes/Messages.rb:165 ../src/scenes/Messages.rb:720
+msgctxt "Messages"
+msgid "Reply"
+msgstr "返信"
+
+#: ../agent/quicknav.rb:529 ../src/Scenes/FeedViewer.rb:147
+msgctxt "FeedViewer"
+msgid "Message liked"
+msgstr "メッセージに「いいね」しました"
+
+#: ../agent/quicknav.rb:529 ../src/Scenes/FeedViewer.rb:147
+msgctxt "FeedViewer"
+msgid "Message disliked"
+msgstr "メッセージに「よくないね」しました"
+
+#: ../agent/quicknav.rb:553 ../src/scenes/Main.rb:374
+msgctxt "Main"
+msgid "Reply"
+msgstr "返信"
+
+#: ../src/EAPI/Documents.rb:3
+msgctxt "License"
+msgid ""
+"Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.\n"
+"Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+msgstr ""
+"エルテンはフリーソフトウェアです：あなたはGNU一般公衆利用許諾契約書バージョン3（フリーソフトウェア財団が発行）に基づいて再配布および/または改変することができます。\n"
+"エルテンは有用であることを願って配布されていますが、いかなる保証もありません；商品性や特定の目的への適合性の黙示的な保証も含みません。詳細についてはGNU一般公衆利用許諾契約書を参照してください。"
+
+#: ../src/EAPI/Documents.rb:3
+msgctxt "License"
+msgid "Elten source code can be found at GitHub:"
+msgstr "エルテンのソースコードはGitHubで見つけることができます："
+
+#: ../src/EAPI/Documents.rb:3
+msgctxt "License"
+msgid "The original content of the GNU General Public License V3 can be found below."
+msgstr "GNU一般公衆利用許諾契約書バージョン3の原文は以下にあります。"
+
+#: ../src/EAPI/Documents.rb:689
+msgctxt "Documentation"
+msgid "Current Elten modifier"
+msgstr "現在のエルテン修飾子"
+
+#: ../src/Scenes/Auctions.rb:25 ../src/Scenes/CallHistory.rb:16 ../src/Scenes/Conference.rb:826 ../src/Scenes/FeedViewer.rb:20 ../src/Scenes/FeedViewer.rb:145 ../src/Scenes/PremiumPackages.rb:370 ../src/Scenes/PremiumPackages.rb:408
+#: ../src/Scenes/PremiumPackages.rb:425 ../src/Scenes/PremiumPackages.rb:435 ../src/eapi/Common.rb:327 ../src/eapi/Common.rb:355 ../src/eapi/Common.rb:363 ../src/eapi/Common.rb:515 ../src/eapi/Common.rb:1222 ../src/eapi/EltenSRV.rb:224 ../src/eapi/EltenSRV.rb:242
+#: ../src/eapi/EltenSRV.rb:313 ../src/eapi/EltenSRV.rb:340 ../src/eapi/EltenSRV.rb:379 ../src/eapi/EltenSRV.rb:394 ../src/eapi/EltenSRV.rb:432 ../src/scenes/Account.rb:497 ../src/scenes/Account.rb:560 ../src/scenes/Account.rb:632 ../src/scenes/Account.rb:640
+#: ../src/scenes/Account.rb:646 ../src/scenes/Authentication.rb:16 ../src/scenes/Authentication.rb:43 ../src/scenes/Authentication.rb:78 ../src/scenes/Authentication.rb:91 ../src/scenes/Ban.rb:72 ../src/scenes/Ban.rb:104 ../src/scenes/Ban.rb:127
+#: ../src/scenes/Blog.rb:94 ../src/scenes/Blog.rb:113 ../src/scenes/Blog.rb:168 ../src/scenes/Blog.rb:189 ../src/scenes/Blog.rb:204 ../src/scenes/Blog.rb:266 ../src/scenes/Blog.rb:378 ../src/scenes/Blog.rb:454 ../src/scenes/Blog.rb:503 ../src/scenes/Blog.rb:525
+#: ../src/scenes/Blog.rb:557 ../src/scenes/Blog.rb:590 ../src/scenes/Blog.rb:724 ../src/scenes/Blog.rb:814 ../src/scenes/Blog.rb:995 ../src/scenes/Blog.rb:1061 ../src/scenes/Blog.rb:1107 ../src/scenes/Blog.rb:1134 ../src/scenes/Blog.rb:1142 ../src/scenes/Blog.rb:1150
+#: ../src/scenes/Blog.rb:1187 ../src/scenes/Blog.rb:1197 ../src/scenes/Blog.rb:1237 ../src/scenes/Blog.rb:1267 ../src/scenes/Blog.rb:1300 ../src/scenes/Blog.rb:1328 ../src/scenes/Blog.rb:1348 ../src/scenes/Blog.rb:1407 ../src/scenes/Blog.rb:1432
+#: ../src/scenes/Blog.rb:1450 ../src/scenes/Blog.rb:1712 ../src/scenes/Blog.rb:1853 ../src/scenes/Blog.rb:1868 ../src/scenes/Blog.rb:1924 ../src/scenes/Blog.rb:1937 ../src/scenes/Blog.rb:2020 ../src/scenes/Blog.rb:2169 ../src/scenes/Blog.rb:2176
+#: ../src/scenes/Blog.rb:2384 ../src/scenes/Blog.rb:2405 ../src/scenes/Blog.rb:2511 ../src/scenes/ForgotPassword.rb:24 ../src/scenes/Forum.rb:626 ../src/scenes/Forum.rb:650 ../src/scenes/Forum.rb:670 ../src/scenes/Forum.rb:690 ../src/scenes/Forum.rb:753
+#: ../src/scenes/Forum.rb:778 ../src/scenes/Forum.rb:791 ../src/scenes/Forum.rb:932 ../src/scenes/Forum.rb:1051 ../src/scenes/Forum.rb:1084 ../src/scenes/Forum.rb:1094 ../src/scenes/Forum.rb:1141 ../src/scenes/Forum.rb:1285 ../src/scenes/Forum.rb:1426
+#: ../src/scenes/Forum.rb:1438 ../src/scenes/Forum.rb:1520 ../src/scenes/Forum.rb:1545 ../src/scenes/Forum.rb:1552 ../src/scenes/Forum.rb:1588 ../src/scenes/Forum.rb:1625 ../src/scenes/Forum.rb:1648 ../src/scenes/Forum.rb:1673 ../src/scenes/Forum.rb:1688
+#: ../src/scenes/Forum.rb:1728 ../src/scenes/Forum.rb:2048 ../src/scenes/Forum.rb:2067 ../src/scenes/Forum.rb:2074 ../src/scenes/Forum.rb:2125 ../src/scenes/Forum.rb:2138 ../src/scenes/Forum.rb:2150 ../src/scenes/Forum.rb:2165 ../src/scenes/Forum.rb:2185
+#: ../src/scenes/Forum.rb:2218 ../src/scenes/Forum.rb:2230 ../src/scenes/Forum.rb:2265 ../src/scenes/Forum.rb:2281 ../src/scenes/Forum.rb:2549 ../src/scenes/Forum.rb:2659 ../src/scenes/Forum.rb:2664 ../src/scenes/Forum.rb:2694 ../src/scenes/Forum.rb:2726
+#: ../src/scenes/Forum.rb:2878 ../src/scenes/Forum.rb:2895 ../src/scenes/Forum.rb:2913 ../src/scenes/Forum.rb:3227 ../src/scenes/Forum.rb:3248 ../src/scenes/Forum.rb:3307 ../src/scenes/Forum.rb:3475 ../src/scenes/Forum.rb:3491 ../src/scenes/Forum.rb:3498
+#: ../src/scenes/Forum.rb:3559 ../src/scenes/Forum.rb:3584 ../src/scenes/Forum.rb:3597 ../src/scenes/Forum.rb:3624 ../src/scenes/Forum.rb:3761 ../src/scenes/Forum.rb:3822 ../src/scenes/Forum.rb:3886 ../src/scenes/Forum.rb:3962 ../src/scenes/Forum.rb:3974
+#: ../src/scenes/Forum.rb:4390 ../src/scenes/Honors.rb:20 ../src/scenes/Honors.rb:138 ../src/scenes/Honors.rb:149 ../src/scenes/Honors.rb:165 ../src/scenes/Honors.rb:210 ../src/scenes/Honors.rb:315 ../src/scenes/Loading.rb:329 ../src/scenes/Main.rb:393
+#: ../src/scenes/Messages.rb:101 ../src/scenes/Messages.rb:182 ../src/scenes/Messages.rb:252 ../src/scenes/Messages.rb:337 ../src/scenes/Messages.rb:373 ../src/scenes/Messages.rb:380 ../src/scenes/Messages.rb:405 ../src/scenes/Messages.rb:495
+#: ../src/scenes/Messages.rb:528 ../src/scenes/Messages.rb:736 ../src/scenes/Messages.rb:743 ../src/scenes/Messages.rb:759 ../src/scenes/Messages.rb:766 ../src/scenes/Messages.rb:817 ../src/scenes/Messages.rb:934 ../src/scenes/Messages.rb:1041
+#: ../src/scenes/Notes.rb:16 ../src/scenes/Notes.rb:107 ../src/scenes/Notes.rb:141 ../src/scenes/Notes.rb:181 ../src/scenes/Notes.rb:194 ../src/scenes/Notes.rb:228 ../src/scenes/Notes.rb:241 ../src/scenes/Notes.rb:271 ../src/scenes/Polls.rb:28
+#: ../src/scenes/Polls.rb:56 ../src/scenes/Polls.rb:137 ../src/scenes/Polls.rb:342 ../src/scenes/Polls.rb:359 ../src/scenes/Polls.rb:374 ../src/scenes/Polls.rb:456 ../src/scenes/Polls.rb:489 ../src/scenes/Polls.rb:499 ../src/scenes/Polls.rb:510
+#: ../src/scenes/Polls.rb:565 ../src/scenes/Polls.rb:579 ../src/scenes/Polls.rb:596 ../src/scenes/SoundThemes.rb:82 ../src/scenes/Sounds.rb:285 ../src/scenes/Sounds.rb:323 ../src/scenes/UserSearch.rb:19
+msgid "Error"
+msgstr "エラー"
+
+#: ../src/Scenes/CallHistory.rb:10 ../src/Scenes/PremiumPackages.rb:4 ../src/scenes/Authentication.rb:10 ../src/scenes/Contacts.rb:13 ../src/scenes/Messages.rb:26 ../src/scenes/Notes.rb:10 ../src/scenes/WhatsNew.rb:15
+msgid "This section is unavailable for guests"
+msgstr "このセクションはゲストには利用できません"
+
+#: ../src/Scenes/CallHistory.rb:34
+msgctxt "CallHistory"
+msgid "Incoming"
+msgstr "着信"
+
+#: ../src/Scenes/CallHistory.rb:37
+msgctxt "CallHistory"
+msgid "Outgoing"
+msgstr "発信"
+
+#: ../src/Scenes/CallHistory.rb:39
+msgctxt "CallHistory"
+msgid "Answered"
+msgstr "応答済み"
+
+#: ../src/Scenes/CallHistory.rb:40
+msgctxt "CallHistory"
+msgid "Unanswered"
+msgstr "未応答"
+
+#: ../src/Scenes/CallHistory.rb:44
+msgctxt "CallHistory"
+msgid "Time"
+msgstr "時間"
+
+#: ../src/Scenes/CallHistory.rb:44
+msgctxt "CallHistory"
+msgid "Status"
+msgstr "ステータス"
+
+#: ../src/Scenes/CallHistory.rb:44
+msgctxt "CallHistory"
+msgid "Type"
+msgstr "種類"
+
+#: ../src/Scenes/CallHistory.rb:45
+msgctxt "CallHistory"
+msgid "Call History"
+msgstr "通話履歴"
+
+#: ../src/Scenes/CallHistory.rb:61 ../src/Scenes/Conference.rb:1408 ../src/Scenes/Conference.rb:1420 ../src/Scenes/Conference.rb:1429 ../src/Scenes/Conference.rb:1490 ../src/Scenes/Conference.rb:1539 ../src/Scenes/Conference.rb:1587 ../src/Scenes/Conference.rb:1674
+#: ../src/Scenes/Conference.rb:2250 ../src/Scenes/PremiumPackages.rb:133 ../src/Scenes/Sponsors.rb:30 ../src/scenes/Account.rb:454 ../src/scenes/Account.rb:572 ../src/scenes/Blog.rb:1223 ../src/scenes/Forum.rb:717 ../src/scenes/Forum.rb:1025
+#: ../src/scenes/Forum.rb:1701 ../src/scenes/Forum.rb:2292 ../src/scenes/Forum.rb:3635 ../src/scenes/Honors.rb:174 ../src/scenes/Honors.rb:295 ../src/scenes/Messages.rb:272 ../src/scenes/Messages.rb:486 ../src/scenes/Messages.rb:792 ../src/scenes/Notes.rb:97
+#: ../src/scenes/Online.rb:37 ../src/scenes/Polls.rb:165 ../src/scenes/Users.rb:56 ../src/scenes/UsersAddedMeToContacts.rb:60 ../src/scenes/Users_RecentlyActived.rb:40 ../src/scenes/Users_RecentlyRegistered.rb:40
+msgid "Refresh"
+msgstr "更新"
+
+#: ../src/Scenes/Conference.rb:18
+msgctxt "Conference"
+msgid "Type your nickname"
+msgstr "ニックネームを入力してください"
+
+#: ../src/Scenes/Conference.rb:39
+msgctxt "Conference"
+msgid "Channel space"
+msgstr "チャンネルスペース"
+
+#: ../src/Scenes/Conference.rb:40
+msgctxt "Conference"
+msgid "Channel users"
+msgstr "チャンネルユーザー"
+
+#: ../src/Scenes/Conference.rb:41
+msgctxt "Conference"
+msgid "Chat history"
+msgstr "チャット履歴"
+
+#: ../src/Scenes/Conference.rb:43
+msgctxt "Conference"
+msgid "More options"
+msgstr "その他のオプション"
+
+#: ../src/Scenes/Conference.rb:44 ../src/Scenes/Conference.rb:1011
+msgctxt "Conference"
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/Scenes/Conference.rb:47
+msgctxt "Conference"
+msgid "Use arrows to move in the channel space"
+msgstr "矢印キーでチャンネルスペースを移動"
+
+#: ../src/Scenes/Conference.rb:48
+msgctxt "Conference"
+msgid "Use shift with left/right arrows to rotate"
+msgstr "Shiftキーと左右矢印キーで回転"
+
+#: ../src/Scenes/Conference.rb:59
+msgctxt "Conference"
+msgid "Deny speech to this user"
+msgstr "このユーザーの発言を禁止する"
+
+#: ../src/Scenes/Conference.rb:64
+msgctxt "Conference"
+msgid "Allow speech to this user"
+msgstr "このユーザーの発言を許可する"
+
+#: ../src/Scenes/Conference.rb:68
+msgctxt "Conference"
+msgid "Allow speech to this user only"
+msgstr "このユーザーのみ発言を許可する"
+
+#: ../src/Scenes/Conference.rb:74
+msgctxt "Conference"
+msgid "Deny speech to all users"
+msgstr "全ユーザーの発言を禁止する"
+
+#: ../src/Scenes/Conference.rb:91
+msgctxt "Conference"
+msgid "User muted"
+msgstr "ユーザーがミュートされました"
+
+#: ../src/Scenes/Conference.rb:93
+msgctxt "Conference"
+msgid "User unmuted"
+msgstr "ユーザーのミュートが解除されました"
+
+#: ../src/Scenes/Conference.rb:96
+msgctxt "Conference"
+msgid "Mute user's streams"
+msgstr "ユーザーのストリームをミュート"
+
+#: ../src/Scenes/Conference.rb:97
+msgctxt "Conference"
+msgid "Unmute user's streams"
+msgstr "ユーザーのストリームのミュートを解除"
+
+#: ../src/Scenes/Conference.rb:101
+msgctxt "Conference"
+msgid "User's streams muted"
+msgstr "ユーザーのストリームがミュートされました"
+
+#: ../src/Scenes/Conference.rb:103
+msgctxt "Conference"
+msgid "User's streams unmuted"
+msgstr "ユーザーのストリームのミュートが解除されました"
+
+#: ../src/Scenes/Conference.rb:106
+msgctxt "Conference"
+msgid "Change user volume"
+msgstr "ユーザーの音量を変更"
+
+#: ../src/Scenes/Conference.rb:107
+msgctxt "Conference"
+msgid "User volume"
+msgstr "ユーザー音量"
+
+#: ../src/Scenes/Conference.rb:121 ../src/Scenes/Conference.rb:1268
+msgctxt "Conference"
+msgid "VST chain"
+msgstr "VSTチェーン"
+
+#: ../src/Scenes/Conference.rb:129 ../src/Scenes/Conference.rb:281
+msgctxt "Conference"
+msgid "Read current position"
+msgstr "現在の位置を読み上げる"
+
+#: ../src/Scenes/Conference.rb:135
+msgctxt "Conference"
+msgid "Hold spacebar to whisper to user"
+msgstr "スペースバーを押しながらユーザーにささやく"
+
+#: ../src/Scenes/Conference.rb:139
+msgctxt "Conference"
+msgid "Accept"
+msgstr "承認"
+
+#: ../src/Scenes/Conference.rb:145
+msgctxt "Conference"
+msgid "Kick"
+msgstr "キック"
+
+#: ../src/Scenes/Conference.rb:151
+msgctxt "Conference"
+msgid "Take over this user's stream"
+msgstr "このユーザーのストリームを引き継ぐ"
+
+#: ../src/Scenes/Conference.rb:157
+msgctxt "Conference"
+msgid "Abandon this user's stream"
+msgstr "このユーザーのストリームを放棄する"
+
+#: ../src/Scenes/Conference.rb:164
+msgctxt "Conference"
+msgid "Invite"
+msgstr "招待"
+
+#: ../src/Scenes/Conference.rb:166
+msgctxt "Conference"
+msgid "User to invite"
+msgstr "招待するユーザー"
+
+#: ../src/Scenes/Conference.rb:171
+msgctxt "Conference"
+msgid "User not found"
+msgstr "ユーザーが見つかりません"
+
+#: ../src/Scenes/Conference.rb:182
+msgctxt "Conference"
+msgid "Total time"
+msgstr "総時間"
+
+#: ../src/Scenes/Conference.rb:183
+msgctxt "Conference"
+msgid "Current packet loss"
+msgstr "現在のパケットロス"
+
+#: ../src/Scenes/Conference.rb:184
+msgctxt "Conference"
+msgid "Current latency"
+msgstr "現在の遅延"
+
+#: ../src/Scenes/Conference.rb:185
+msgctxt "Conference"
+msgid "Bytes sent"
+msgstr "送信バイト数"
+
+#: ../src/Scenes/Conference.rb:186
+msgctxt "Conference"
+msgid "Bytes received"
+msgstr "受信バイト数"
+
+#: ../src/Scenes/Conference.rb:192
+msgctxt "Conference"
+msgid "Please wait, you will be accepted soon."
+msgstr "お待ちください。まもなく承認されます。"
+
+#: ../src/Scenes/Conference.rb:210
+msgctxt "Conference"
+msgid "Stream taken over by %{supervisor}"
+msgstr "%{supervisor} がストリームを引き継ぎました"
+
+#: ../src/Scenes/Conference.rb:238
+msgctxt "Conference"
+msgid "Message of the day"
+msgstr "今日のメッセージ"
+
+#: ../src/Scenes/Conference.rb:239
+msgctxt "Conference"
+msgid "OK"
+msgstr "OK"
+
+#: ../src/Scenes/Conference.rb:256
+msgctxt "Conference"
+msgid "%{user} has rolled %{value} dot on a %{count}-sided dice"
+msgid_plural "%{user} has rolled %{value} dots on a %{count}-sided dice"
+msgstr[0] "%{user}は%{count}面のサイコロで%{value}を出しました"
+
+#: ../src/Scenes/Conference.rb:282
+msgctxt "Conference"
+msgid "Read channel size"
+msgstr "チャンネルのサイズを読み上げる"
+
+#: ../src/Scenes/Conference.rb:303
+msgctxt "Conference"
+msgid "Would you like to disconnect?"
+msgstr "切断しますか？"
+
+#: ../src/Scenes/Conference.rb:331 ../src/Scenes/Conference.rb:404 ../src/Scenes/Conference.rb:557
+msgctxt "Conference"
+msgid "Channels"
+msgstr "チャンネル"
+
+#: ../src/Scenes/Conference.rb:355
+msgctxt "Conference"
+msgid "Join"
+msgstr "参加"
+
+#: ../src/Scenes/Conference.rb:358 ../src/Scenes/Conference.rb:475
+msgctxt "Conference"
+msgid "Channel password"
+msgstr "チャンネルパスワード"
+
+#: ../src/Scenes/Conference.rb:375
+msgctxt "Conference"
+msgid "Follow"
+msgstr "フォロー"
+
+#: ../src/Scenes/Conference.rb:377
+msgctxt "Conference"
+msgid "Channel followed"
+msgstr "チャンネルをフォローしました"
+
+#: ../src/Scenes/Conference.rb:382
+msgctxt "Conference"
+msgid "Unfollow"
+msgstr "フォローを解除"
+
+#: ../src/Scenes/Conference.rb:384
+msgctxt "Conference"
+msgid "Channel unfollowed"
+msgstr "チャンネルのフォローを解除しました"
+
+#: ../src/Scenes/Conference.rb:390 ../src/Scenes/Conference.rb:414
+msgctxt "Conference"
+msgid "Channel details"
+msgstr "チャンネルの詳細"
+
+#: ../src/Scenes/Conference.rb:392
+msgctxt "Conference"
+msgid "Creator"
+msgstr "作成者"
+
+#: ../src/Scenes/Conference.rb:393
+msgctxt "Conference"
+msgid "Administrators"
+msgstr "管理者"
+
+#: ../src/Scenes/Conference.rb:394 ../src/Scenes/Conference.rb:548
+msgctxt "Conference"
+msgid "Language"
+msgstr "言語"
+
+#: ../src/Scenes/Conference.rb:395
+msgctxt "Conference"
+msgid "Followers count: "
+msgstr "フォロワー数："
+
+#: ../src/Scenes/Conference.rb:396
+msgctxt "Conference"
+msgid "This channel is password-protected."
+msgstr "このチャンネルはパスワードで保護されています。"
+
+#: ../src/Scenes/Conference.rb:397
+msgctxt "Conference"
+msgid "A waiting room is enabled on this channel."
+msgstr "このチャンネルには待合室が有効になっています。"
+
+#: ../src/Scenes/Conference.rb:399
+msgctxt "Conference"
+msgid "Room id"
+msgstr "ルームID"
+
+#: ../src/Scenes/Conference.rb:400
+msgctxt "Conference"
+msgid "URL for joining using Web Browser"
+msgstr "ウェブブラウザで参加するためのURL"
+
+#: ../src/Scenes/Conference.rb:402 ../src/Scenes/Conference.rb:551
+msgctxt "Conference"
+msgid "Channel bitrate"
+msgstr "チャンネルのビットレート"
+
+#: ../src/Scenes/Conference.rb:403 ../src/Scenes/Conference.rb:552
+msgctxt "Conference"
+msgid "Channel frame size"
+msgstr "チャンネルのフレームサイズ"
+
+#: ../src/Scenes/Conference.rb:405 ../src/Scenes/Conference.rb:558
+msgctxt "Conference"
+msgid "Space Virtualization"
+msgstr "空間仮想化"
+
+#: ../src/Scenes/Conference.rb:412 ../src/Scenes/Conference.rb:558
+msgctxt "Conference"
+msgid "Round table"
+msgstr "円卓"
+
+#: ../src/Scenes/Conference.rb:417 ../src/Scenes/Conference.rb:1325
+msgctxt "Conference"
+msgid "Edit channel"
+msgstr "チャンネルを編集"
+
+#: ../src/Scenes/Conference.rb:427
+msgctxt "Conference"
+msgid "Leave"
+msgstr "退出"
+
+#: ../src/Scenes/Conference.rb:434
+msgctxt "Conference"
+msgid "Create channel"
+msgstr "チャンネルを作成"
+
+#: ../src/Scenes/Conference.rb:442
+msgctxt "Conference"
+msgid "Show channels in unknown languages"
+msgstr "未知の言語のチャンネルを表示"
+
+#: ../src/Scenes/Conference.rb:443
+msgctxt "Conference"
+msgid "Hide channels in unknown languages"
+msgstr "未知の言語のチャンネルを非表示"
+
+#: ../src/Scenes/Conference.rb:453
+msgctxt "Conference"
+msgid "Show private channels"
+msgstr "プライベートチャンネルを表示"
+
+#: ../src/Scenes/Conference.rb:456
+msgctxt "Conference"
+msgid "Select user"
+msgstr "ユーザーを選択"
+
+#: ../src/Scenes/Conference.rb:462
+msgctxt "Conference"
+msgid "Refresh"
+msgstr "更新"
+
+#: ../src/Scenes/Conference.rb:507
+msgctxt "Conference"
+msgid "Audiophile"
+msgstr "オーディオ愛好家向け"
+
+#: ../src/Scenes/Conference.rb:508
+msgctxt "Conference"
+msgid "High quality"
+msgstr "高品質"
+
+#: ../src/Scenes/Conference.rb:509
+msgctxt "Conference"
+msgid "Standard quality"
+msgstr "標準品質"
+
+#: ../src/Scenes/Conference.rb:510
+msgctxt "Conference"
+msgid "Standard quality with surround sound"
+msgstr "サラウンドサウンド付き標準品質"
+
+#: ../src/Scenes/Conference.rb:511
+msgctxt "Conference"
+msgid "Standard quality with round table"
+msgstr "円卓付き標準品質"
+
+#: ../src/Scenes/Conference.rb:512
+msgctxt "Conference"
+msgid "Quality for mobile or limited connections"
+msgstr "モバイルまたは制限された接続向け品質"
+
+#: ../src/Scenes/Conference.rb:513
+msgctxt "Conference"
+msgid "Quality for mobile or limited connections with surround sound"
+msgstr "サラウンドサウンド付きモバイルまたは制限された接続向け品質"
+
+#: ../src/Scenes/Conference.rb:514
+msgctxt "Conference"
+msgid "Quality for mobile or limited connections with round table"
+msgstr "円卓付きモバイルまたは制限された接続向け品質"
+
+#: ../src/Scenes/Conference.rb:515
+msgctxt "Conference"
+msgid "Low quality"
+msgstr "低品質"
+
+#: ../src/Scenes/Conference.rb:547
+msgctxt "Conference"
+msgid "Channel name"
+msgstr "チャンネル名"
+
+#: ../src/Scenes/Conference.rb:549
+msgctxt "Conference"
+msgid "Message of the Day"
+msgstr "今日のメッセージ"
+
+#: ../src/Scenes/Conference.rb:550
+msgctxt "Conference"
+msgid "Quality preset"
+msgstr "品質プリセット"
+
+#: ../src/Scenes/Conference.rb:550
+msgctxt "Conference"
+msgid "Custom"
+msgstr "カスタム"
+
+#: ../src/Scenes/Conference.rb:553
+msgctxt "Conference"
+msgid "Constant"
+msgstr "一定"
+
+#: ../src/Scenes/Conference.rb:553
+msgctxt "Conference"
+msgid "Variable"
+msgstr "可変"
+
+#: ../src/Scenes/Conference.rb:553
+msgctxt "Conference"
+msgid "Constrained variable"
+msgstr "制約付き可変"
+
+#: ../src/Scenes/Conference.rb:553
+msgctxt "Conference"
+msgid "Bitrate type"
+msgstr "ビットレートタイプ"
+
+#: ../src/Scenes/Conference.rb:554
+msgctxt "Conference"
+msgid "Codec application"
+msgstr "コーデックアプリケーション"
+
+#: ../src/Scenes/Conference.rb:555
+msgctxt "Conference"
+msgid "Enable forward error correction"
+msgstr "前方誤り訂正を有効にする"
+
+#: ../src/Scenes/Conference.rb:556
+msgctxt "Conference"
+msgid "Disable encoding prediction"
+msgstr "エンコード予測を無効にする"
+
+#: ../src/Scenes/Conference.rb:559
+msgctxt "Conference"
+msgid "Enable conference mode (only channel administrators and allowed users can speak)"
+msgstr "会議モードを有効にする（チャンネル管理者と許可されたユーザーのみが発言可能）"
+
+#: ../src/Scenes/Conference.rb:560
+msgctxt "Conference"
+msgid "Enable waiting room"
+msgstr "待合室を有効にする"
+
+#: ../src/Scenes/Conference.rb:561
+msgctxt "Conference"
+msgid "Allow guests to join this channel"
+msgstr "ゲストがこのチャンネルに参加することを許可する"
+
+#: ../src/Scenes/Conference.rb:562
+msgctxt "Conference"
+msgid "Make this channel hidden"
+msgstr "このチャンネルを非表示にする"
+
+#: ../src/Scenes/Conference.rb:563
+msgctxt "Conference"
+msgid "Store as permanent channel"
+msgstr "永続的なチャンネルとして保存"
+
+#: ../src/Scenes/Conference.rb:564
+msgctxt "Conference"
+msgid "Channel width"
+msgstr "チャンネルの幅"
+
+#: ../src/Scenes/Conference.rb:565
+msgctxt "Conference"
+msgid "Channel height"
+msgstr "チャンネルの高さ"
+
+#: ../src/Scenes/Conference.rb:566
+msgctxt "Conference"
+msgid "Channel password (leave this field blank to set a channel without a password)"
+msgstr "チャンネルパスワード（パスワードなしにするにはこのフィールドを空白のままにしてください）"
+
+#: ../src/Scenes/Conference.rb:567
+msgctxt "Conference"
+msgid "Channel encryption"
+msgstr "チャンネルの暗号化"
+
+#: ../src/Scenes/Conference.rb:567
+msgctxt "Conference"
+msgid "None"
+msgstr "なし"
+
+#: ../src/Scenes/Conference.rb:568
+msgctxt "Conference"
+msgid "Create"
+msgstr "作成"
+
+#: ../src/Scenes/Conference.rb:569
+msgctxt "Conference"
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: ../src/Scenes/Conference.rb:603
+msgctxt "Conference"
+msgid "Edit"
+msgstr "編集"
+
+#: ../src/Scenes/Conference.rb:670
+msgctxt "Conference"
+msgid "Channel width and height must be at least 1"
+msgstr "チャンネルの幅と高さは少なくとも1でなければなりません"
+
+#: ../src/Scenes/Conference.rb:674
+msgctxt "Conference"
+msgid "%{value} is the maximum allowed channel width and height"
+msgstr "チャンネルの幅と高さの最大許容値は%{value}です"
+
+#: ../src/Scenes/Conference.rb:745 ../src/Scenes/Conference.rb:760
+msgctxt "Conference"
+msgid "%{name}, everywhere"
+msgstr "%{name}、どこでも"
+
+#: ../src/Scenes/Conference.rb:747 ../src/Scenes/Conference.rb:762
+msgctxt "Conference"
+msgid "%{name}, located at %{x}, %{y}"
+msgstr "%{name}、位置 %{x}, %{y}"
+
+#: ../src/Scenes/Conference.rb:750 ../src/Scenes/Conference.rb:1047
+msgctxt "Conference"
+msgid "Channel scenery"
+msgstr "チャンネルの風景"
+
+#: ../src/Scenes/Conference.rb:752
+msgctxt "Conference"
+msgid "Add object"
+msgstr "オブジェクトを追加"
+
+#: ../src/Scenes/Conference.rb:771
+msgctxt "Conference"
+msgid "Go to object"
+msgstr "オブジェクトに移動"
+
+#: ../src/Scenes/Conference.rb:775
+msgctxt "Conference"
+msgid "Remove object"
+msgstr "オブジェクトを削除"
+
+#: ../src/Scenes/Conference.rb:796
+msgctxt "Conference"
+msgid "Available objects"
+msgstr "利用可能なオブジェクト"
+
+#: ../src/Scenes/Conference.rb:797 ../src/Scenes/Conference.rb:1783 ../src/Scenes/Conference.rb:1815 ../src/Scenes/Conference.rb:1852
+msgctxt "Conference"
+msgid "Here"
+msgstr "ここ"
+
+#: ../src/Scenes/Conference.rb:797 ../src/Scenes/Conference.rb:1624 ../src/Scenes/Conference.rb:1696 ../src/Scenes/Conference.rb:1783 ../src/Scenes/Conference.rb:1815 ../src/Scenes/Conference.rb:1852
+msgctxt "Conference"
+msgid "Everywhere"
+msgstr "どこでも"
+
+#: ../src/Scenes/Conference.rb:797
+msgctxt "Conference"
+msgid "Object position"
+msgstr "オブジェクトの位置"
+
+#: ../src/Scenes/Conference.rb:798
+msgctxt "Conference"
+msgid "Place object"
+msgstr "オブジェクトを配置"
+
+#: ../src/Scenes/Conference.rb:804
+msgctxt "Conference"
+msgid "Upload new sound"
+msgstr "新しいサウンドをアップロード"
+
+#: ../src/Scenes/Conference.rb:809
+msgctxt "Conference"
+msgid "This file is too large"
+msgstr "このファイルは大きすぎます"
+
+#: ../src/Scenes/Conference.rb:824 ../src/Scenes/Conference.rb:1529 ../src/Scenes/Conference.rb:1578
+msgctxt "Conference"
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/Scenes/Conference.rb:828
+msgctxt "Conference"
+msgid "Object deleted"
+msgstr "オブジェクトが削除されました"
+
+#: ../src/Scenes/Conference.rb:854 ../src/Scenes/Conference.rb:882 ../src/Scenes/Conference.rb:2254
+msgctxt "Conference"
+msgid "Destination"
+msgstr "宛先"
+
+#: ../src/Scenes/Conference.rb:855 ../src/Scenes/Conference.rb:2255
+msgctxt "Conference"
+msgid "File name"
+msgstr "ファイル名"
+
+#: ../src/Scenes/Conference.rb:856 ../src/Scenes/Conference.rb:884 ../src/Scenes/Conference.rb:958 ../src/eapi/Controls.rb:3393 ../src/eapi/Controls.rb:4346 ../src/eapi/Controls.rb:4424 ../src/eapi/Controls.rb:4487 ../src/scenes/Account.rb:116
+#: ../src/scenes/Blog.rb:1250 ../src/scenes/Blog.rb:1389 ../src/scenes/Blog.rb:1564 ../src/scenes/Clock.rb:11 ../src/scenes/Clock.rb:70 ../src/scenes/Forum.rb:737 ../src/scenes/Forum.rb:763 ../src/scenes/Forum.rb:1464 ../src/scenes/Forum.rb:1613
+#: ../src/scenes/Forum.rb:3839 ../src/scenes/Forum.rb:4351 ../src/scenes/Honors.rb:186 ../src/scenes/Honors.rb:221 ../src/scenes/Notes.rb:158 ../src/scenes/Notes.rb:175 ../src/scenes/Polls.rb:239 ../src/scenes/Settings.rb:118
+msgid "Save"
+msgstr "保存"
+
+#: ../src/Scenes/Conference.rb:864 ../src/Scenes/Conference.rb:891
+msgctxt "Conference"
+msgid "Saving began"
+msgstr "保存を開始しました"
+
+#: ../src/Scenes/Conference.rb:873 ../src/Scenes/Conference.rb:900
+msgctxt "Conference"
+msgid "Save completed"
+msgstr "保存が完了しました"
+
+#: ../src/Scenes/Conference.rb:883
+msgctxt "Conference"
+msgid "Directory name"
+msgstr "ディレクトリ名"
+
+#: ../src/Scenes/Conference.rb:915 ../src/Scenes/Conference.rb:917 ../src/Scenes/Conference.rb:919 ../src/Scenes/Conference.rb:956
+msgctxt "Conference"
+msgid "Left"
+msgstr "左"
+
+#: ../src/Scenes/Conference.rb:921 ../src/Scenes/Conference.rb:923 ../src/Scenes/Conference.rb:925 ../src/Scenes/Conference.rb:956
+msgctxt "Conference"
+msgid "Right"
+msgstr "右"
+
+#: ../src/Scenes/Conference.rb:938
+msgctxt "Conference"
+msgid "Set push to talk shortcut"
+msgstr "プッシュトゥトークのショートカットを設定"
+
+#: ../src/Scenes/Conference.rb:940
+msgctxt "Conference"
+msgid "Push to talk shortcut"
+msgstr "プッシュトゥトークのショートカット"
+
+#: ../src/Scenes/Conference.rb:949
+msgctxt "Conference"
+msgid "Pause key"
+msgstr "ポーズキー"
+
+#: ../src/Scenes/Conference.rb:953
+msgctxt "Conference"
+msgid "No key"
+msgstr "キーなし"
+
+#: ../src/Scenes/Conference.rb:956
+msgctxt "Conference"
+msgid "Any"
+msgstr "任意"
+
+#: ../src/Scenes/Conference.rb:956
+msgctxt "Conference"
+msgid "Modifiers"
+msgstr "修飾キー"
+
+#: ../src/Scenes/Conference.rb:957
+msgctxt "Conference"
+msgid "Key"
+msgstr "キー"
+
+#: ../src/Scenes/Conference.rb:996
+msgctxt "Conference"
+msgid "No keys selected"
+msgstr "キーが選択されていません"
+
+#: ../src/Scenes/Conference.rb:1008
+msgctxt "Conference"
+msgid "Input volume"
+msgstr "入力音量"
+
+#: ../src/Scenes/Conference.rb:1009
+msgctxt "Conference"
+msgid "Master volume"
+msgstr "マスターボリューム"
+
+#: ../src/Scenes/Conference.rb:1010 ../src/Scenes/Conference.rb:1652 ../src/Scenes/Conference.rb:1735
+msgctxt "Conference"
+msgid "Stream volume"
+msgstr "ストリーム音量"
+
+#: ../src/Scenes/Conference.rb:1032
+msgctxt "Conference"
+msgid "Status"
+msgstr "ステータス"
+
+#: ../src/Scenes/Conference.rb:1054
+msgctxt "Conference"
+msgid "Remove soundcard stream"
+msgstr "サウンドカードのストリームを削除"
+
+#: ../src/Scenes/Conference.rb:1067
+msgctxt "Conference"
+msgid "Stream from soundcard"
+msgstr "サウンドカードからストリーム"
+
+#: ../src/Scenes/Conference.rb:1072 ../src/Scenes/Conference.rb:1850 ../src/Scenes/Conference.rb:2000
+msgctxt "Conference"
+msgid "Loopback device"
+msgstr "ループバックデバイス"
+
+#: ../src/Scenes/Conference.rb:1072 ../src/Scenes/Conference.rb:1850 ../src/Scenes/Conference.rb:2000
+msgctxt "Conference"
+msgid "Select soundcard to stream"
+msgstr "ストリームするサウンドカードを選択"
+
+#: ../src/Scenes/Conference.rb:1073 ../src/Scenes/Conference.rb:1851
+msgctxt "Conference"
+msgid "Turn on the listening"
+msgstr "リスニングをオンにする"
+
+#: ../src/Scenes/Conference.rb:1074
+msgctxt "Conference"
+msgid "Stream"
+msgstr "ストリーム"
+
+#: ../src/Scenes/Conference.rb:1113 ../src/Scenes/Conference.rb:1760 ../src/Scenes/Conference.rb:1937
+msgctxt "Conference"
+msgid "Scroll backward"
+msgstr "逆方向にスクロール"
+
+#: ../src/Scenes/Conference.rb:1114 ../src/Scenes/Conference.rb:1765 ../src/Scenes/Conference.rb:1940
+msgctxt "Conference"
+msgid "Scroll forward"
+msgstr "順方向にスクロール"
+
+#: ../src/Scenes/Conference.rb:1115
+msgctxt "Conference"
+msgid "Toggle pause"
+msgstr "一時停止を切り替え"
+
+#: ../src/Scenes/Conference.rb:1128
+msgctxt "Conference"
+msgid "Remove shoutcast stream"
+msgstr "Shoutcastストリームを削除"
+
+#: ../src/Scenes/Conference.rb:1134
+msgctxt "Conference"
+msgid "Stream this conference to a shoutcast server"
+msgstr "この会議をShoutcastサーバーにストリーム"
+
+#: ../src/Scenes/Conference.rb:1138
+msgctxt "Conference"
+msgid "Server type"
+msgstr "サーバータイプ"
+
+#: ../src/Scenes/Conference.rb:1139
+msgctxt "Conference"
+msgid "Server"
+msgstr "サーバー"
+
+#: ../src/Scenes/Conference.rb:1140
+msgctxt "Conference"
+msgid "Port"
+msgstr "ポート"
+
+#: ../src/Scenes/Conference.rb:1141
+msgctxt "Conference"
+msgid "Stream ID"
+msgstr "ストリームID"
+
+#: ../src/Scenes/Conference.rb:1142
+msgctxt "Conference"
+msgid "Username (empty for no user)"
+msgstr "ユーザー名（ユーザーなしの場合は空欄）"
+
+#: ../src/Scenes/Conference.rb:1143
+msgctxt "Conference"
+msgid "Password"
+msgstr "パスワード"
+
+#: ../src/Scenes/Conference.rb:1144
+msgctxt "Conference"
+msgid "Stream name"
+msgstr "ストリーム名"
+
+#: ../src/Scenes/Conference.rb:1145
+msgctxt "Conference"
+msgid "Stream bitrate"
+msgstr "ストリームビットレート"
+
+#: ../src/Scenes/Conference.rb:1146
+msgctxt "Conference"
+msgid "Make this stream public"
+msgstr "このストリームを公開する"
+
+#: ../src/Scenes/Conference.rb:1147
+msgctxt "Conference"
+msgid "Start"
+msgstr "開始"
+
+#: ../src/Scenes/Conference.rb:1193 ../src/Scenes/Conference.rb:1691
+msgctxt "Conference"
+msgid "My streams"
+msgstr "自分のストリーム"
+
+#: ../src/Scenes/Conference.rb:1194 ../src/Scenes/Conference.rb:1618
+msgctxt "Conference"
+msgid "Channel streams"
+msgstr "チャンネルストリーム"
+
+#: ../src/Scenes/Conference.rb:1210
+msgctxt "Conference"
+msgid "Request speech"
+msgstr "発言をリクエスト"
+
+#: ../src/Scenes/Conference.rb:1215
+msgctxt "Conference"
+msgid "Refrain speech"
+msgstr "発言を控える"
+
+#: ../src/Scenes/Conference.rb:1223
+msgctxt "Conference"
+msgid "Streaming"
+msgstr "ストリーミング"
+
+#: ../src/Scenes/Conference.rb:1234
+msgctxt "Conference"
+msgid "Change volumes"
+msgstr "音量を変更"
+
+#: ../src/Scenes/Conference.rb:1238
+msgctxt "Conference"
+msgid "Finish saving"
+msgstr "保存を終了"
+
+#: ../src/Scenes/Conference.rb:1242
+msgctxt "Conference"
+msgid "Save this conference to a file"
+msgstr "この会議をファイルに保存"
+
+#: ../src/Scenes/Conference.rb:1243
+msgctxt "Conference"
+msgid "Save mixed stream to a file"
+msgstr "ミックスされたストリームをファイルに保存"
+
+#: ../src/Scenes/Conference.rb:1246
+msgctxt "Conference"
+msgid "Save separate streams (experimental)"
+msgstr "個別のストリームを保存（実験的）"
+
+#: ../src/Scenes/Conference.rb:1253
+msgctxt "Conference"
+msgid "Push to talk"
+msgstr "プッシュトゥトーク"
+
+#: ../src/Scenes/Conference.rb:1273
+msgctxt "Conference"
+msgid "Miscellaneous"
+msgstr "その他"
+
+#: ../src/Scenes/Conference.rb:1278
+msgctxt "Conference"
+msgid "Cardboard"
+msgstr "段ボール"
+
+#: ../src/Scenes/Conference.rb:1280
+msgctxt "Conference"
+msgid "Show status"
+msgstr "ステータスを表示"
+
+#: ../src/Scenes/Conference.rb:1281
+msgctxt "Conference"
+msgid "Change output soundcard"
+msgstr "出力サウンドカードを変更"
+
+#: ../src/Scenes/Conference.rb:1283
+msgctxt "Conference"
+msgid "Use Elten soundcard"
+msgstr "Eltenサウンドカードを使用"
+
+#: ../src/Scenes/Conference.rb:1286
+msgctxt "Conference"
+msgid "Select soundcard"
+msgstr "サウンドカードを選択"
+
+#: ../src/Scenes/Conference.rb:1287
+msgctxt "Conference"
+msgid "Select"
+msgstr "選択"
+
+#: ../src/Scenes/Conference.rb:1307
+msgctxt "Conference"
+msgid "Channel"
+msgstr "チャンネル"
+
+#: ../src/Scenes/Conference.rb:1309
+msgctxt "Conference"
+msgid "Show banned users"
+msgstr "禁止されたユーザーを表示"
+
+#: ../src/Scenes/Conference.rb:1314
+msgctxt "Conference"
+msgid "Show channel administrators"
+msgstr "チャンネル管理者を表示"
+
+#: ../src/Scenes/Conference.rb:1320
+msgctxt "Conference"
+msgid "Show channel whitelist"
+msgstr "チャンネルのホワイトリストを表示"
+
+#: ../src/Scenes/Conference.rb:1331
+msgctxt "Conference"
+msgid "Show channels"
+msgstr "チャンネルを表示"
+
+#: ../src/Scenes/Conference.rb:1340
+msgctxt "Conference"
+msgid "Full deck"
+msgstr "フルデッキ"
+
+#: ../src/Scenes/Conference.rb:1342
+msgctxt "Conference"
+msgid "Two colours"
+msgstr "2色"
+
+#: ../src/Scenes/Conference.rb:1344
+msgctxt "Conference"
+msgid "Small deck"
+msgstr "小さいデッキ"
+
+#: ../src/Scenes/Conference.rb:1346
+msgctxt "Conference"
+msgid "Two colours of a small deck"
+msgstr "小さいデッキの2色"
+
+#: ../src/Scenes/Conference.rb:1348
+msgctxt "Conference"
+msgid "No jokers"
+msgstr "ジョーカーなし"
+
+#: ../src/Scenes/Conference.rb:1350
+msgctxt "Conference"
+msgid "UNO"
+msgstr "UNO"
+
+#: ../src/Scenes/Conference.rb:1357
+msgctxt "Conference"
+msgid "Decks"
+msgstr "デッキ"
+
+#: ../src/Scenes/Conference.rb:1358
+msgctxt "Conference"
+msgid "My cards"
+msgstr "自分のカード"
+
+#: ../src/Scenes/Conference.rb:1359
+msgctxt "Conference"
+msgid "Placed cards"
+msgstr "置かれたカード"
+
+#: ../src/Scenes/Conference.rb:1360 ../src/eapi/Controls.rb:4518 ../src/scenes/Loading.rb:367 ../src/scenes/Log.rb:14 ../src/scenes/Polls.rb:622
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/Scenes/Conference.rb:1379 ../src/Scenes/Conference.rb:1425
+msgctxt "Conference"
+msgid "Pick a card"
+msgstr "カードを引く"
+
+#: ../src/Scenes/Conference.rb:1382
+msgctxt "Conference"
+msgid "Shuffle"
+msgstr "シャッフル"
+
+#: ../src/Scenes/Conference.rb:1383
+msgctxt "Conference"
+msgid "Are you sure you want to shuffle this deck? All placed cards will be returned to this deck."
+msgstr "このデッキをシャッフルしてもよろしいですか？すべての置かれたカードはこのデッキに戻されます。"
+
+#: ../src/Scenes/Conference.rb:1389 ../src/Scenes/Conference.rb:1459
+msgctxt "Conference"
+msgid "Deck history"
+msgstr "デッキの履歴"
+
+#: ../src/Scenes/Conference.rb:1390
+msgctxt "Conference"
+msgid "Delete a deck"
+msgstr "デッキを削除"
+
+#: ../src/Scenes/Conference.rb:1391
+msgctxt "Conference"
+msgid "Are you sure you want to delete this deck?"
+msgstr "このデッキを削除してもよろしいですか？"
+
+#: ../src/Scenes/Conference.rb:1399
+msgctxt "Conference"
+msgid "Add new deck"
+msgstr "新しいデッキを追加"
+
+#: ../src/Scenes/Conference.rb:1402
+msgctxt "Conference"
+msgid "Deck type"
+msgstr "デッキタイプ"
+
+#: ../src/Scenes/Conference.rb:1413
+msgctxt "Conference"
+msgid "Place a card"
+msgstr "カードを置く"
+
+#: ../src/Scenes/Conference.rb:1416
+msgctxt "Conference"
+msgid "Replace a card"
+msgstr "カードを交換"
+
+#: ../src/Scenes/Conference.rb:1449
+msgctxt "Conference"
+msgid "Picked a card"
+msgstr "カードを引きました"
+
+#: ../src/Scenes/Conference.rb:1451
+msgctxt "Conference"
+msgid "Replaced a card"
+msgstr "カードを交換しました"
+
+#: ../src/Scenes/Conference.rb:1453
+msgctxt "Conference"
+msgid "Shuffled a deck"
+msgstr "デッキをシャッフルしました"
+
+#: ../src/Scenes/Conference.rb:1455
+msgctxt "Conference"
+msgid "Placed %{cardname}"
+msgstr "%{cardname} を置きました"
+
+#: ../src/Scenes/Conference.rb:1463
+msgctxt "Conference"
+msgid "Banned users"
+msgstr "禁止されたユーザー"
+
+#: ../src/Scenes/Conference.rb:1472
+msgctxt "Conference"
+msgid "Unban"
+msgstr "禁止を解除"
+
+#: ../src/Scenes/Conference.rb:1479
+msgctxt "Conference"
+msgid "Ban user"
+msgstr "ユーザーを禁止"
+
+#: ../src/Scenes/Conference.rb:1480
+msgctxt "Conference"
+msgid "User to ban"
+msgstr "禁止するユーザー"
+
+#: ../src/Scenes/Conference.rb:1506
+msgctxt "Conference"
+msgid "administrators"
+msgstr "管理者"
+
+#: ../src/Scenes/Conference.rb:1518
+msgctxt "Conference"
+msgid "Add administrator"
+msgstr "管理者を追加"
+
+#: ../src/Scenes/Conference.rb:1519
+msgctxt "Conference"
+msgid "User to grant administration privileges to"
+msgstr "管理者権限を付与するユーザー"
+
+#: ../src/Scenes/Conference.rb:1555
+msgctxt "Conference"
+msgid "Channel whitelist"
+msgstr "チャンネルのホワイトリスト"
+
+#: ../src/Scenes/Conference.rb:1567
+msgctxt "Conference"
+msgid "Add to whitelist"
+msgstr "ホワイトリストに追加"
+
+#: ../src/Scenes/Conference.rb:1568
+msgctxt "Conference"
+msgid "User to add to channel whitelist"
+msgstr "チャンネルのホワイトリストに追加するユーザー"
+
+#: ../src/Scenes/Conference.rb:1618 ../src/Scenes/Conference.rb:1691 ../src/Scenes/Conference.rb:1783 ../src/Scenes/Conference.rb:1815 ../src/Scenes/Conference.rb:1852
+msgctxt "Conference"
+msgid "Location"
+msgstr "位置"
+
+#: ../src/Scenes/Conference.rb:1618
+msgctxt "Conference"
+msgid "User"
+msgstr "ユーザー"
+
+#: ../src/Scenes/Conference.rb:1626 ../src/Scenes/Conference.rb:1698 ../src/Scenes/Conference.rb:1783 ../src/Scenes/Conference.rb:1815 ../src/Scenes/Conference.rb:1852
+msgctxt "Conference"
+msgid "Right next to me"
+msgstr "私のすぐ隣"
+
+#: ../src/Scenes/Conference.rb:1638
+msgctxt "Conference"
+msgid "Mute stream"
+msgstr "ストリームをミュート"
+
+#: ../src/Scenes/Conference.rb:1639
+msgctxt "Conference"
+msgid "Unmute stream"
+msgstr "ストリームのミュートを解除"
+
+#: ../src/Scenes/Conference.rb:1643
+msgctxt "Conference"
+msgid "Stream unmuted"
+msgstr "ストリームのミュートが解除されました"
+
+#: ../src/Scenes/Conference.rb:1645
+msgctxt "Conference"
+msgid "Stream muted"
+msgstr "ストリームがミュートされました"
+
+#: ../src/Scenes/Conference.rb:1648 ../src/Scenes/Conference.rb:1733 ../src/Scenes/Conference.rb:1913
+msgctxt "Conference"
+msgid "Change volume"
+msgstr "音量を変更"
+
+#: ../src/Scenes/Conference.rb:1669
+msgctxt "Conference"
+msgid "Go to stream"
+msgstr "ストリームに移動"
+
+#: ../src/Scenes/Conference.rb:1693 ../src/Scenes/Conference.rb:1895
+msgctxt "Conference"
+msgid "Master mix"
+msgstr "マスターミックス"
+
+#: ../src/Scenes/Conference.rb:1716
+msgctxt "Conference"
+msgid "Show sources"
+msgstr "ソースを表示"
+
+#: ../src/Scenes/Conference.rb:1722
+msgctxt "Conference"
+msgid "Locally mute"
+msgstr "ローカルでミュート"
+
+#: ../src/Scenes/Conference.rb:1723
+msgctxt "Conference"
+msgid "Locally unmute"
+msgstr "ローカルのミュートを解除"
+
+#: ../src/Scenes/Conference.rb:1728
+msgctxt "Conference"
+msgid "Locally unmuted"
+msgstr "ローカルのミュートが解除されました"
+
+#: ../src/Scenes/Conference.rb:1730
+msgctxt "Conference"
+msgid "Locally muted"
+msgstr "ローカルでミュートされました"
+
+#: ../src/Scenes/Conference.rb:1753 ../src/Scenes/Conference.rb:1932
+msgctxt "Conference"
+msgid "Toggle stream"
+msgstr "ストリームを切り替え"
+
+#: ../src/Scenes/Conference.rb:1772
+msgctxt "Conference"
+msgid "Remove stream"
+msgstr "ストリームを削除"
+
+#: ../src/Scenes/Conference.rb:1780
+msgctxt "Conference"
+msgid "New file stream"
+msgstr "新しいファイルストリーム"
+
+#: ../src/Scenes/Conference.rb:1782 ../src/Scenes/Conference.rb:1954 ../src/Scenes/Conference.rb:2036
+msgctxt "Conference"
+msgid "File"
+msgstr "ファイル"
+
+#: ../src/Scenes/Conference.rb:1784 ../src/Scenes/Conference.rb:1816 ../src/Scenes/Conference.rb:1853 ../src/Scenes/Conference.rb:1955 ../src/Scenes/Conference.rb:1976 ../src/Scenes/Conference.rb:2001
+msgctxt "Conference"
+msgid "Place"
+msgstr "場所"
+
+#: ../src/Scenes/Conference.rb:1812
+msgctxt "Conference"
+msgid "New Internet stream"
+msgstr "新しいインターネットストリーム"
+
+#: ../src/Scenes/Conference.rb:1814 ../src/Scenes/Conference.rb:1975
+msgctxt "Conference"
+msgid "Stream URL"
+msgstr "ストリームURL"
+
+#: ../src/Scenes/Conference.rb:1845
+msgctxt "Conference"
+msgid "New soundcard stream"
+msgstr "新しいサウンドカードストリーム"
+
+#: ../src/Scenes/Conference.rb:1897
+msgctxt "Conference"
+msgid "Sources of %{name}"
+msgstr "%{name}のソース"
+
+#: ../src/Scenes/Conference.rb:1915
+msgctxt "Conference"
+msgid "Source volume"
+msgstr "ソース音量"
+
+#: ../src/Scenes/Conference.rb:1944
+msgctxt "Conference"
+msgid "Remove source"
+msgstr "ソースを削除"
+
+#: ../src/Scenes/Conference.rb:1952
+msgctxt "Conference"
+msgid "Add file"
+msgstr "ファイルを追加"
+
+#: ../src/Scenes/Conference.rb:1973
+msgctxt "Conference"
+msgid "Add Internet stream"
+msgstr "インターネットストリームを追加"
+
+#: ../src/Scenes/Conference.rb:1995
+msgctxt "Conference"
+msgid "Add soundcard"
+msgstr "サウンドカードを追加"
+
+#: ../src/Scenes/Conference.rb:2036
+msgctxt "Conference"
+msgid "State"
+msgstr "状態"
+
+#: ../src/Scenes/Conference.rb:2036
+msgctxt "Conference"
+msgid "VST Plugins"
+msgstr "VSTプラグイン"
+
+#: ../src/Scenes/Conference.rb:2036 ../src/Scenes/Conference.rb:2050
+msgctxt "Conference"
+msgid "Name"
+msgstr "名前"
+
+#: ../src/Scenes/Conference.rb:2050
+msgctxt "Conference"
+msgid "Unit"
+msgstr "単位"
+
+#: ../src/Scenes/Conference.rb:2050
+msgctxt "Conference"
+msgid "Display"
+msgstr "表示"
+
+#: ../src/Scenes/Conference.rb:2050
+msgctxt "Conference"
+msgid "Value"
+msgstr "値"
+
+#: ../src/Scenes/Conference.rb:2050
+msgctxt "Conference"
+msgid "VST parameters"
+msgstr "VSTパラメーター"
+
+#: ../src/Scenes/Conference.rb:2051
+msgctxt "Conference"
+msgid "Use left/right arrows to adjust values"
+msgstr "左右の矢印キーで値を調整"
+
+#: ../src/Scenes/Conference.rb:2071
+msgctxt "Conference"
+msgid "Edit parameter"
+msgstr "パラメーターを編集"
+
+#: ../src/Scenes/Conference.rb:2072
+msgctxt "Conference"
+msgid "Parameter value"
+msgstr "パラメーター値"
+
+#: ../src/Scenes/Conference.rb:2080
+msgctxt "Conference"
+msgid "Set to default"
+msgstr "デフォルトに設定"
+
+#: ../src/Scenes/Conference.rb:2142
+msgctxt "Conference"
+msgid "Disabled"
+msgstr "無効"
+
+#: ../src/Scenes/Conference.rb:2142
+msgctxt "Conference"
+msgid "Enabled"
+msgstr "有効"
+
+#: ../src/Scenes/Conference.rb:2152
+msgctxt "Conference"
+msgid "Show parameters"
+msgstr "パラメーターを表示"
+
+#: ../src/Scenes/Conference.rb:2156
+msgctxt "Conference"
+msgid "Enable"
+msgstr "有効にする"
+
+#: ../src/Scenes/Conference.rb:2157
+msgctxt "Conference"
+msgid "Disable"
+msgstr "無効にする"
+
+#: ../src/Scenes/Conference.rb:2168
+msgctxt "Conference"
+msgid "Show editor"
+msgstr "エディターを表示"
+
+#: ../src/Scenes/Conference.rb:2169
+msgctxt "Conference"
+msgid "Hide editor"
+msgstr "エディターを非表示"
+
+#: ../src/Scenes/Conference.rb:2181
+msgctxt "Conference"
+msgid "Change program"
+msgstr "プログラムを変更"
+
+#: ../src/Scenes/Conference.rb:2182
+msgctxt "Conference"
+msgid "Select program"
+msgstr "プログラムを選択"
+
+#: ../src/Scenes/Conference.rb:2191
+msgctxt "Conference"
+msgid "Move up"
+msgstr "上へ移動"
+
+#: ../src/Scenes/Conference.rb:2198
+msgctxt "Conference"
+msgid "Move down"
+msgstr "下へ移動"
+
+#: ../src/Scenes/Conference.rb:2204
+msgctxt "Conference"
+msgid "Remove VST"
+msgstr "VSTを削除"
+
+#: ../src/Scenes/Conference.rb:2209 ../src/Scenes/Conference.rb:2257
+msgctxt "Conference"
+msgid "Export"
+msgstr "エクスポート"
+
+#: ../src/Scenes/Conference.rb:2213
+msgctxt "Conference"
+msgid "Import"
+msgstr "インポート"
+
+#: ../src/Scenes/Conference.rb:2218
+msgctxt "Conference"
+msgid "Save current chain"
+msgstr "現在のチェーンを保存"
+
+#: ../src/Scenes/Conference.rb:2219
+msgctxt "Conference"
+msgid "Name for this chain"
+msgstr "このチェーンの名前"
+
+#: ../src/Scenes/Conference.rb:2234 ../src/Scenes/Conference.rb:2292 ../src/Scenes/Conference.rb:2340 ../src/eapi/Controls.rb:3425 ../src/eapi/Controls.rb:4557 ../src/scenes/Account.rb:300 ../src/scenes/Account.rb:304 ../src/scenes/Blog.rb:1269
+#: ../src/scenes/Blog.rb:1302 ../src/scenes/Blog.rb:1767 ../src/scenes/Blog.rb:1771 ../src/scenes/Clock.rb:35 ../src/scenes/Clock.rb:80 ../src/scenes/Forum.rb:1135 ../src/scenes/Forum.rb:1627 ../src/scenes/Forum.rb:1675 ../src/scenes/Forum.rb:4453
+#: ../src/scenes/Forum.rb:4457 ../src/scenes/Honors.rb:212 ../src/scenes/Messages.rb:239 ../src/scenes/Messages.rb:371 ../src/scenes/Settings.rb:343 ../src/scenes/Settings.rb:347 ../src/scenes/SoundThemes.rb:73 ../src/scenes/SoundThemes.rb:207
+#: ../src/scenes/Sounds.rb:246
+msgid "Saved"
+msgstr "保存されました"
+
+#: ../src/Scenes/Conference.rb:2238
+msgctxt "Conference"
+msgid "Add VST"
+msgstr "VSTを追加"
+
+#: ../src/Scenes/Conference.rb:2239
+msgctxt "Conference"
+msgid "Select VST version 2 file to be loaded"
+msgstr "読み込むVSTバージョン2のファイルを選択"
+
+#: ../src/Scenes/Conference.rb:2245
+msgctxt "Conference"
+msgid "Saved VST chains"
+msgstr "保存されたVSTチェーン"
+
+#: ../src/Scenes/Conference.rb:2256
+msgctxt "Conference"
+msgid "Export current preset"
+msgstr "現在のプリセットをエクスポート"
+
+#: ../src/Scenes/Conference.rb:2256
+msgctxt "Conference"
+msgid "Export full bank"
+msgstr "フルバンクをエクスポート"
+
+#: ../src/Scenes/Conference.rb:2256
+msgctxt "Conference"
+msgid "Export type"
+msgstr "エクスポートタイプ"
+
+#: ../src/Scenes/Conference.rb:2299
+msgctxt "Conference"
+msgid "Select preset or bank file"
+msgstr "プリセットまたはバンクファイルを選択"
+
+#: ../src/Scenes/Conference.rb:2378
+msgctxt "Conference"
+msgid "Saved chains"
+msgstr "保存されたチェーン"
+
+#: ../src/Scenes/Conference.rb:2384 ../src/Scenes/FeedViewer.rb:153 ../src/eapi/Controls.rb:2608 ../src/eapi/Controls.rb:4550 ../src/scenes/Account.rb:557 ../src/scenes/Blog.rb:222 ../src/scenes/Blog.rb:477 ../src/scenes/Main.rb:401 ../src/scenes/Messages.rb:777
+#: ../src/scenes/Notes.rb:82 ../src/scenes/Notes.rb:160 ../src/scenes/Polls.rb:133 ../src/scenes/Polls.rb:662
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/Scenes/Conference.rb:2385
+msgctxt "Conference"
+msgid "Are you sure you want to delete saved chain of name %{name}?"
+msgstr "名前が%{name}の保存されたチェーンを削除してもよろしいですか？"
+
+#: ../src/Scenes/Conference.rb:2391
+msgctxt "Conference"
+msgid "Rename chain"
+msgstr "チェーンの名前を変更"
+
+#: ../src/Scenes/Conference.rb:2392
+msgctxt "Conference"
+msgid "Chain name"
+msgstr "チェーン名"
+
+#: ../src/Scenes/Conference.rb:2408
+msgctxt "Conference"
+msgid "Are you sure you want to apply chain of name %{name}?"
+msgstr "名前が%{name}のチェーンを適用してもよろしいですか？"
+
+#: ../src/Scenes/Conference.rb:2421
+msgctxt "Conference"
+msgid "Chain imported"
+msgstr "チェーンがインポートされました"
+
+#: ../src/Scenes/Documentation.rb:10
+msgctxt "Documentation"
+msgid "License agreement"
+msgstr "ライセンス契約"
+
+#: ../src/Scenes/Documentation.rb:13
+msgctxt "Documentation"
+msgid "EltenLink terms and conditions"
+msgstr "エルテンリンク利用規約"
+
+#: ../src/Scenes/Documentation.rb:16
+msgctxt "Documentation"
+msgid "EltenLink Privacy Policy"
+msgstr "エルテンリンクプライバシーポリシー"
+
+#: ../src/Scenes/Documentation.rb:19
+msgctxt "Documentation"
+msgid "Read me"
+msgstr "お読みください"
+
+#: ../src/Scenes/Documentation.rb:22
+msgctxt "Documentation"
+msgid "Information about migration to Elten version 2.4"
+msgstr "エルテンバージョン2.4への移行に関する情報"
+
+#: ../src/Scenes/Documentation.rb:27
+msgctxt "Documentation"
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/Scenes/FAQ.rb:8
+msgctxt "FAQ"
+msgid "Frequently asked questions"
+msgstr "よくある質問"
+
+#: ../src/Scenes/FeedViewer.rb:59
+msgctxt "FeedViewer"
+msgid "%{count} user likes it"
+msgid_plural "%{count} users like it"
+msgstr[0] "%{count}人が「いいね！」と言っています"
+
+#: ../src/Scenes/FeedViewer.rb:99
+msgctxt "FeedViewer"
+msgid "Show responses"
+msgstr "返信を表示"
+
+#: ../src/Scenes/FeedViewer.rb:103
+msgctxt "FeedViewer"
+msgid "Show conversation"
+msgstr "会話を表示"
+
+#: ../src/Scenes/FeedViewer.rb:108
+msgctxt "FeedViewer"
+msgid "Show likes"
+msgstr "「いいね！」を表示"
+
+#: ../src/Scenes/FeedViewer.rb:114
+msgctxt "FeedViewer"
+msgid "Users who like this post"
+msgstr "この投稿を「いいね！」したユーザー"
+
+#: ../src/Scenes/FeedViewer.rb:126
+msgctxt "FeedViewer"
+msgid "Reply"
+msgstr "返信"
+
+#: ../src/Scenes/FeedViewer.rb:141
+msgctxt "FeedViewer"
+msgid "Like this message"
+msgstr "このメッセージに「いいね！」する"
+
+#: ../src/Scenes/FeedViewer.rb:142
+msgctxt "FeedViewer"
+msgid "Dislike this message"
+msgstr "このメッセージの「いいね！」を取り消す"
+
+#: ../src/Scenes/FeedViewer.rb:154
+msgctxt "FeedViewer"
+msgid "Are you sure you want to delete this post?"
+msgstr "この投稿を削除してもよろしいですか？"
+
+#: ../src/Scenes/FeedViewer.rb:162
+msgctxt "FeedViewer"
+msgid "Publish to a feed"
+msgstr "フィードに投稿"
+
+#: ../src/Scenes/FeedViewer.rb:167
+msgctxt "FeedViewer"
+msgid "Message"
+msgstr "メッセージ"
+
+#: ../src/Scenes/IIKeys.rb:4
+msgctxt "IIKeys"
+msgid "Navigate up or down on lists"
+msgstr "リストを上下に移動"
+
+#: ../src/Scenes/IIKeys.rb:5
+msgctxt "IIKeys"
+msgid "Change current tab"
+msgstr "現在のタブを変更"
+
+#: ../src/Scenes/IIKeys.rb:6
+msgctxt "IIKeys"
+msgid "Jump to the first or last item"
+msgstr "最初または最後の項目にジャンプ"
+
+#: ../src/Scenes/IIKeys.rb:7
+msgctxt "IIKeys"
+msgid "In messages, jump to another conversation"
+msgstr "メッセージ内で別の会話にジャンプ"
+
+#: ../src/Scenes/IIKeys.rb:8
+msgctxt "IIKeys"
+msgid "Activate the selected item"
+msgstr "選択した項目をアクティブにする"
+
+#: ../src/Scenes/IIKeys.rb:9
+msgctxt "IIKeys"
+msgid "Cancel speech and stop currently played audio"
+msgstr "音声をキャンセルし、再生中のオーディオを停止"
+
+#: ../src/Scenes/IIKeys.rb:10
+msgctxt "IIKeys"
+msgid "Repeat the currently selected item"
+msgstr "現在選択されている項目を繰り返す"
+
+#: ../src/Scenes/IIKeys.rb:11
+msgctxt "IIKeys"
+msgid "Reply"
+msgstr "返信"
+
+#: ../src/Scenes/IIKeys.rb:12
+msgctxt "IIKeys"
+msgid "Like or dislike a feed message"
+msgstr "フィードメッセージに「いいね」または「よくないね」をする"
+
+#: ../src/Scenes/IIKeys.rb:13
+msgctxt "IIKeys"
+msgid "Write a new message"
+msgstr "新しいメッセージを書く"
+
+#: ../src/Scenes/IIKeys.rb:14
+msgctxt "IIKeys"
+msgid "Post on a feed"
+msgstr "フィードに投稿する"
+
+#: ../src/Scenes/IIKeys.rb:37
+msgctxt "IIKeys"
+msgid "Invisible Interface Hotkeys"
+msgstr "インビジブルインターフェースのホットキー"
+
+#: ../src/Scenes/PremiumPackages.rb:13
+msgctxt "PremiumPackages"
+msgid "status"
+msgstr "ステータス"
+
+#: ../src/Scenes/PremiumPackages.rb:13
+msgctxt "PremiumPackages"
+msgid "Yearly price"
+msgstr "年間価格"
+
+#: ../src/Scenes/PremiumPackages.rb:13
+msgctxt "PremiumPackages"
+msgid "Monthly price"
+msgstr "月間価格"
+
+#: ../src/Scenes/PremiumPackages.rb:13
+msgctxt "PremiumPackages"
+msgid "Conversion price"
+msgstr "換算価格"
+
+#: ../src/Scenes/PremiumPackages.rb:13
+msgctxt "PremiumPackages"
+msgid "Premium packages"
+msgstr "プレミアムパッケージ"
+
+#: ../src/Scenes/PremiumPackages.rb:30
+msgctxt "PremiumPackages"
+msgid "Courier"
+msgstr "クーリエ"
+
+#: ../src/Scenes/PremiumPackages.rb:31
+msgctxt "PremiumPackages"
+msgid "Following forums in not moderated groups"
+msgstr "モデレートされていないグループのフォーラムをフォローする"
+
+#: ../src/Scenes/PremiumPackages.rb:32
+msgctxt "PremiumPackages"
+msgid "Disabling signatures visibility"
+msgstr "シグネチャの表示を無効にする"
+
+#: ../src/Scenes/PremiumPackages.rb:33
+msgctxt "PremiumPackages"
+msgid "Thread marking and bookmarks"
+msgstr "スレッドのマークとブックマーク"
+
+#: ../src/Scenes/PremiumPackages.rb:34
+msgctxt "PremiumPackages"
+msgid "Private messages protection against erroneous removal"
+msgstr "誤った削除からプライベートメッセージを保護"
+
+#: ../src/Scenes/PremiumPackages.rb:35
+msgctxt "PremiumPackages"
+msgid "History of mentions and replying to mentions"
+msgstr "メンションの履歴とメンションへの返信"
+
+#: ../src/Scenes/PremiumPackages.rb:36
+msgctxt "PremiumPackages"
+msgid "Groups pinning"
+msgstr "グループのピン留め"
+
+#: ../src/Scenes/PremiumPackages.rb:37
+msgctxt "PremiumPackages"
+msgid "Following blog posts"
+msgstr "ブログ投稿のフォロー"
+
+#: ../src/Scenes/PremiumPackages.rb:38
+msgctxt "PremiumPackages"
+msgid "Extended limit of attachment size in private messages to 32MB"
+msgstr "プライベートメッセージの添付ファイルサイズ制限を32MBに拡大"
+
+#: ../src/Scenes/PremiumPackages.rb:39
+msgctxt "PremiumPackages"
+msgid "Attaching polls to private messages"
+msgstr "プライベートメッセージに投票を添付する"
+
+#: ../src/Scenes/PremiumPackages.rb:40
+msgctxt "PremiumPackages"
+msgid "Using MarkDown in forum posts"
+msgstr "フォーラム投稿でMarkDownを使用する"
+
+#: ../src/Scenes/PremiumPackages.rb:41
+msgctxt "PremiumPackages"
+msgid "Reading transcriptions of audio posts in recommended groups"
+msgstr "おすすめグループ内の音声投稿の文字起こしを読む"
+
+#: ../src/Scenes/PremiumPackages.rb:45
+msgctxt "PremiumPackages"
+msgid "Audiophile"
+msgstr "オーディオ愛好家"
+
+#: ../src/Scenes/PremiumPackages.rb:46
+msgctxt "PremiumPackages"
+msgid "Lifting the 2-minute limit for private voice messages"
+msgstr "プライベートボイスメッセージの2分制限を解除"
+
+#: ../src/Scenes/PremiumPackages.rb:47
+msgctxt "PremiumPackages"
+msgid "Lifting the 32kbps quality limit in private voice messages"
+msgstr "プライベートボイスメッセージの32kbps品質制限を解除"
+
+#: ../src/Scenes/PremiumPackages.rb:48
+msgctxt "PremiumPackages"
+msgid "Recording conferences"
+msgstr "会議を録音する"
+
+#: ../src/Scenes/PremiumPackages.rb:49
+msgctxt "PremiumPackages"
+msgid "Creation of up to three public channels in conferences"
+msgstr "会議で最大3つのパブリックチャンネルを作成"
+
+#: ../src/Scenes/PremiumPackages.rb:50
+msgctxt "PremiumPackages"
+msgid "Creation of group channels in conferences"
+msgstr "会議でグループチャンネルを作成"
+
+#: ../src/Scenes/PremiumPackages.rb:51
+msgctxt "PremiumPackages"
+msgid "Using VST plugins in conferences"
+msgstr "会議でVSTプラグインを使用する"
+
+#: ../src/Scenes/PremiumPackages.rb:52
+msgctxt "PremiumPackages"
+msgid "Setting specific ringtones for users"
+msgstr "ユーザーごとに特定の着信音を設定"
+
+#: ../src/Scenes/PremiumPackages.rb:54
+msgctxt "PremiumPackages"
+msgid "Splitting audio into chapters"
+msgstr "音声をチャプターに分割する"
+
+#: ../src/Scenes/PremiumPackages.rb:55
+msgctxt "PremiumPackages"
+msgid "Creating hidden channels in conferences"
+msgstr "会議で隠しチャンネルを作成"
+
+#: ../src/Scenes/PremiumPackages.rb:59
+msgctxt "PremiumPackages"
+msgid "Scribe"
+msgstr "スクライブ"
+
+#: ../src/Scenes/PremiumPackages.rb:60
+msgctxt "PremiumPackages"
+msgid "Creation of second and following blogs"
+msgstr "2つ目以降のブログの作成"
+
+#: ../src/Scenes/PremiumPackages.rb:61
+msgctxt "PremiumPackages"
+msgid "Pinning blogs to groups"
+msgstr "ブログをグループにピン留め"
+
+#: ../src/Scenes/PremiumPackages.rb:62
+msgctxt "PremiumPackages"
+msgid "Spell checking"
+msgstr "スペルチェック"
+
+#: ../src/Scenes/PremiumPackages.rb:63
+msgctxt "PremiumPackages"
+msgid "Changing of blog address"
+msgstr "ブログアドレスの変更"
+
+#: ../src/Scenes/PremiumPackages.rb:64
+msgctxt "PremiumPackages"
+msgid "Option to disable request for support on blogs"
+msgstr "ブログでサポートのリクエストを無効にするオプション"
+
+#: ../src/Scenes/PremiumPackages.rb:65
+msgctxt "PremiumPackages"
+msgid "Informing about new blog followers"
+msgstr "新しいブログフォロワーを通知"
+
+#: ../src/Scenes/PremiumPackages.rb:66
+msgctxt "PremiumPackages"
+msgid "Translator"
+msgstr "トランスレーター"
+
+#: ../src/Scenes/PremiumPackages.rb:67
+msgctxt "PremiumPackages"
+msgid "Blog posts scheduling"
+msgstr "ブログ投稿のスケジュール設定"
+
+#: ../src/Scenes/PremiumPackages.rb:71
+msgctxt "PremiumPackages"
+msgid "Director"
+msgstr "ディレクター"
+
+#: ../src/Scenes/PremiumPackages.rb:72
+msgctxt "PremiumPackages"
+msgid "Conference streaming to shoutcast servers"
+msgstr "会議をShoutcastサーバーにストリーミング"
+
+#: ../src/Scenes/PremiumPackages.rb:73
+msgctxt "PremiumPackages"
+msgid "Setting VST plugins on specific users"
+msgstr "特定のユーザーにVSTプラグインを設定"
+
+#: ../src/Scenes/PremiumPackages.rb:74
+msgctxt "PremiumPackages"
+msgid "Placing own sceneries in channels"
+msgstr "チャンネルに独自の風景を配置"
+
+#: ../src/Scenes/PremiumPackages.rb:75
+msgctxt "PremiumPackages"
+msgid "Creating conference-mode channels, where only administrators and allowed users can speak"
+msgstr "管理者と許可されたユーザーのみが話せる会議モードのチャンネルを作成"
+
+#: ../src/Scenes/PremiumPackages.rb:76
+msgctxt "PremiumPackages"
+msgid "Setting different output soundcard for conferences than the one selected in Elten"
+msgstr "Eltenで選択したものとは異なる出力サウンドカードを会議で設定"
+
+#: ../src/Scenes/PremiumPackages.rb:77
+msgctxt "PremiumPackages"
+msgid "Changing channels dimensions"
+msgstr "チャンネルのサイズを変更"
+
+#: ../src/Scenes/PremiumPackages.rb:81
+msgctxt "PremiumPackages"
+msgid "Orchestra package"
+msgstr "オーケストラパッケージ"
+
+#: ../src/Scenes/PremiumPackages.rb:82
+msgctxt "PremiumPackages"
+msgid "Includes profits from courier, audiophile, scribe and director"
+msgstr "Courier、Audiophile、Scribe、Directorの特典を含む"
+
+#: ../src/Scenes/PremiumPackages.rb:86
+msgctxt "PremiumPackages"
+msgid "Sponsorship package"
+msgstr "スポンサーシップパッケージ"
+
+#: ../src/Scenes/PremiumPackages.rb:87
+msgctxt "PremiumPackages"
+msgid "Includes profits from all other packages, including future packages"
+msgstr "将来のパッケージを含む、他のすべてのパッケージの特典を含む"
+
+#: ../src/Scenes/PremiumPackages.rb:88
+msgctxt "PremiumPackages"
+msgid "Special assigning of user on lists and forum"
+msgstr "リストとフォーラムでのユーザーの特別な指定"
+
+#: ../src/Scenes/PremiumPackages.rb:89
+msgctxt "PremiumPackages"
+msgid "Entry in the list of sponsors"
+msgstr "スポンサー一覧への掲載"
+
+#: ../src/Scenes/PremiumPackages.rb:95
+msgctxt "PremiumPackages"
+msgid "Show profits"
+msgstr "特典を表示"
+
+#: ../src/Scenes/PremiumPackages.rb:100 ../src/Scenes/PremiumPackages.rb:145
+msgctxt "PremiumPackages"
+msgid "Buy"
+msgstr "購入"
+
+#: ../src/Scenes/PremiumPackages.rb:101 ../src/Scenes/PremiumPackages.rb:146
+msgctxt "PremiumPackages"
+msgid "Extend"
+msgstr "延長"
+
+#: ../src/Scenes/PremiumPackages.rb:108 ../src/Scenes/PremiumPackages.rb:147
+msgctxt "PremiumPackages"
+msgid "Activate package using code"
+msgstr "コードを使用してパッケージを有効化"
+
+#: ../src/Scenes/PremiumPackages.rb:109 ../src/Scenes/PremiumPackages.rb:148
+msgctxt "PremiumPackages"
+msgid "Extend package using code"
+msgstr "コードを使用してパッケージを延長"
+
+#: ../src/Scenes/PremiumPackages.rb:116 ../src/Scenes/PremiumPackages.rb:152
+msgctxt "PremiumPackages"
+msgid "Convert"
+msgstr "変換"
+
+#: ../src/Scenes/PremiumPackages.rb:123 ../src/Scenes/PremiumPackages.rb:153
+msgctxt "PremiumPackages"
+msgid "Buy premium codes for use by any user"
+msgstr "誰でも使用できるプレミアムコードを購入"
+
+#: ../src/Scenes/PremiumPackages.rb:129
+msgctxt "PremiumPackages"
+msgid "Change currency"
+msgstr "通貨を変更"
+
+#: ../src/Scenes/PremiumPackages.rb:139
+msgctxt "PremiumPackages"
+msgid "Polish zloty"
+msgstr "ポーランドズロチ"
+
+#: ../src/Scenes/PremiumPackages.rb:139
+msgctxt "PremiumPackages"
+msgid "Euro"
+msgstr "ユーロ"
+
+#: ../src/Scenes/PremiumPackages.rb:139
+msgctxt "PremiumPackages"
+msgid "US dollar"
+msgstr "米ドル"
+
+#: ../src/Scenes/PremiumPackages.rb:139
+msgctxt "PremiumPackages"
+msgid "British pound"
+msgstr "英ポンド"
+
+#: ../src/Scenes/PremiumPackages.rb:139
+msgctxt "PremiumPackages"
+msgid "Select your currency."
+msgstr "通貨を選択してください。"
+
+#: ../src/Scenes/PremiumPackages.rb:150
+msgctxt "PremiumPackages"
+msgid "Profits of package %{name}"
+msgstr "パッケージ%{name}の特典"
+
+#: ../src/Scenes/PremiumPackages.rb:155
+msgctxt "PremiumPackages"
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/Scenes/PremiumPackages.rb:218
+msgctxt "PremiumPackages"
+msgid "Inactive"
+msgstr "非アクティブ"
+
+#: ../src/Scenes/PremiumPackages.rb:219
+msgctxt "PremiumPackages"
+msgid "Active until %{time}"
+msgstr "%{time}まで有効"
+
+#: ../src/Scenes/PremiumPackages.rb:250
+msgctxt "PremiumPackages"
+msgid ""
+"Regardless of the remaining duration of other packages, they will be replaced by the selected package. This package will be activated for a period of one year. The remaining period for other packages will be deducted from the package price. Do you want to continue?"
+msgstr "他のパッケージの残り期間にかかわらず、選択したパッケージに置き換えられます。このパッケージは1年間有効になります。他のパッケージの残り期間はパッケージ価格から差し引かれます。続行しますか？"
+
+#: ../src/Scenes/PremiumPackages.rb:252
+msgctxt "PremiumPackages"
+msgid "This package is currently unavailable. Try to buy it in the next month."
+msgstr "このパッケージは現在利用できません。来月に購入を試みてください。"
+
+#: ../src/Scenes/PremiumPackages.rb:257
+msgctxt "PremiumPackages"
+msgid "One year"
+msgstr "1年"
+
+#: ../src/Scenes/PremiumPackage.rb:257
+msgctxt "PremiumPackage"
+msgid "One month"
+msgstr "1か月"
+
+#: ../src/Scenes/PremiumPackages.rb:257
+msgctxt "PremiumPackages"
+msgid "How long do you want to buy this package for?"
+msgstr "このパッケージをどのくらいの期間購入しますか？"
+
+#: ../src/Scenes/PremiumPackages.rb:262
+msgctxt "PremiumPackages"
+msgid ""
+"EltenLink's premium packages are given to users as a reward for supporting the portal.\n"
+"A project of this size cannot exist without the help of users.\n"
+"The granting of a premium package does not constitute a commitment or a commercial contract. The user who supports the project is aware that if the necessary amount is not raised for EltenLink to continue, the premium packages will become unavailable."
+msgstr ""
+"エルテンリンクのプレミアムパッケージは、ポータルを支援していただいたユーザーへの報酬として提供されます。\n"
+"この規模のプロジェクトは、ユーザーの支援なしでは存在できません。\n"
+"プレミアムパッケージの付与は、契約や商業的な約束を構成するものではありません。プロジェクトを支援するユーザーは、EltenLinkを継続するために必要な資金が集まらない場合、プレミアムパッケージが利用できなくなることを理解しています。"
+
+#: ../src/Scenes/PremiumPackages.rb:262 ../src/Scenes/PremiumPackages.rb:331
+msgctxt "PremiumPackages"
+msgid "Information"
+msgstr "情報"
+
+#: ../src/Scenes/PremiumPackages.rb:266 ../src/Scenes/PremiumPackages.rb:332
+msgctxt "PremiumPackages"
+msgid "I accept"
+msgstr "同意します"
+
+#: ../src/Scenes/PremiumPackages.rb:267
+msgctxt "PremiumPackages"
+msgid "I refuse"
+msgstr "同意しません"
+
+#: ../src/Scenes/PremiumPackages.rb:287
+msgctxt "PremiumPackages"
+msgid "Traditional bank transfer"
+msgstr "従来の銀行振込"
+
+#: ../src/Scenes/PremiumPackages.rb:288
+msgctxt "PremiumPackages"
+msgid "Paypal (using Paypal account or credit/debit card)"
+msgstr "Paypal（Paypalアカウントまたはクレジット/デビットカードを使用）"
+
+#: ../src/Scenes/PremiumPackages.rb:289
+msgctxt "PremiumPackages"
+msgid "Przelewy24 (fast transfer from polish banks)"
+msgstr "Przelewy24（ポーランドの銀行からの高速送金）"
+
+#: ../src/Scenes/PremiumPackages.rb:292
+msgctxt "PremiumPackages"
+msgid "Select payment method"
+msgstr "支払い方法を選択"
+
+#: ../src/Scenes/PremiumPackages.rb:298
+msgctxt "PremiumPackages"
+msgid "Acceptance"
+msgstr "受諾"
+
+#: ../src/Scenes/PremiumPackages.rb:299
+msgctxt "PremiumPackages"
+msgid "Accept"
+msgstr "同意する"
+
+#: ../src/Scenes/PremiumPackages.rb:300
+msgctxt "PremiumPackages"
+msgid "Reject"
+msgstr "同意しない"
+
+#: ../src/Scenes/PremiumPackages.rb:310
+msgctxt "PremiumPackages"
+msgid "Below are the transfer details.\n"
+msgstr "以下は振込詳細です。\n"
+
+#: ../src/Scenes/PremiumPackages.rb:312
+msgctxt "PremiumPackages"
+msgid "In the title of the transfer, please indicate your user name on the EltenLink portal and which package the payment concerns."
+msgstr "振込のタイトルには、EltenLinkポータルでのユーザー名と、支払い対象のパッケージを記載してください。"
+
+#: ../src/Scenes/PremiumPackages.rb:314
+msgctxt "PremiumPackages"
+msgid "If you wish to receive a code that can be used to activate any of the packages: %{packages} by any user, mark this information in the transfer title."
+msgstr "任意のユーザーがパッケージ%{packages}を有効化できるコードを受け取りたい場合は、その旨を振込のタイトルに記載してください。"
+
+#: ../src/Scenes/PremiumPackages.rb:316
+msgctxt "PremiumPackages"
+msgid ""
+"Please note that if you transfer a larger amount, the remainder will be treated as a donation.\n"
+"\n"
+"In order to reduce the processing time of your payment, you can forward the transfer confirmation to the Council of Elders."
+msgstr ""
+"より大きな金額を振り込んだ場合、残額は寄付として扱われますのでご注意ください。\n"
+"\n"
+"お支払いの処理時間を短縮するために、振込確認を長老会に転送することができます。"
+
+#: ../src/Scenes/PremiumPackages.rb:320
+msgctxt "PremiumPackages"
+msgid ""
+"National transfer details (from Poland):\n"
+"%{holder}\n"
+"Address: %{address}\n"
+"Account number: %{placcount}\n"
+"\n"
+"Additional data for foreign transfers:\n"
+"IBAN number: %{iban}\n"
+"BIC / SWIFT: %{swift}\n"
+"Bank address: %{bankaddress}\n"
+"Sort code: %{sortcode}"
+msgstr ""
+"国内振込の詳細（ポーランドから）：\n"
+"%{holder}\n"
+"住所：%{address}\n"
+"口座番号：%{placcount}\n"
+"\n"
+"海外振込の追加情報：\n"
+"IBAN番号：%{iban}\n"
+"BIC / SWIFT：%{swift}\n"
+"銀行住所：%{bankaddress}\n"
+"ソートコード：%{sortcode}"
+
+#: ../src/Scenes/PremiumPackages.rb:338
+msgctxt "PremiumPackages"
+msgid "This payment method requires a redirect to an external website. A web browser will open. Do you wish to continue?"
+msgstr "この支払い方法では外部ウェブサイトへのリダイレクトが必要です。ウェブブラウザが開きます。続行しますか？"
+
+#: ../src/Scenes/PremiumPackages.rb:359 ../src/Scenes/PremiumPackages.rb:394
+msgctxt "PremiumPackages"
+msgid "How many premium codes would you like to buy?"
+msgstr "いくつのプレミアムコードを購入しますか？"
+
+#: ../src/Scenes/PremiumPackages.rb:367 ../src/Scenes/PremiumPackages.rb:402
+msgctxt "PremiumPackages"
+msgid "You will be charged a %{amount} commission for the selected payment method. Do you want to continue?"
+msgstr "選択した支払い方法には%{amount}の手数料がかかります。続行しますか？"
+
+#: ../src/Scenes/PremiumPackages.rb:403
+msgctxt "PremiumPackages"
+msgid "Enter blik code"
+msgstr "BLIKコードを入力"
+
+#: ../src/Scenes/PremiumPackages.rb:410
+msgctxt "PremiumPackages"
+msgid "Payment has been ordered. Additional confirmation may be required. The order will be processed once the payment is complete."
+msgstr "支払いが注文されました。追加の確認が必要な場合があります。支払いが完了すると、注文が処理されます。"
+
+#: ../src/Scenes/PremiumPackages.rb:415
+msgctxt "PremiumPackages"
+msgid "Type code to activate this package"
+msgstr "このパッケージを有効化するコードを入力"
+
+#: ../src/Scenes/PremiumPackages.rb:421
+msgctxt "PremiumPackages"
+msgid "Code not found."
+msgstr "コードが見つかりません。"
+
+#: ../src/Scenes/PremiumPackages.rb:423
+msgctxt "PremiumPackages"
+msgid "This code has been already used."
+msgstr "このコードは既に使用されています。"
+
+#: ../src/Scenes/PremiumPackages.rb:432
+msgctxt "PremiumPackages"
+msgid "The package %{name} will be active until %{time}. This code will be used up and you will not be able to use it again. Do you want to continue?"
+msgstr "パッケージ%{name}は%{time}まで有効です。このコードは消費され、再度使用することはできません。続行しますか？"
+
+#: ../src/Scenes/PremiumPackages.rb:437
+msgctxt "PremiumPackages"
+msgid "Package activated"
+msgstr "パッケージが有効化されました"
+
+#: ../src/Scenes/Sponsors.rb:13
+msgctxt "Users_Sponsors"
+msgid "Sponsors"
+msgstr "スポンサー"
+
+#: ../src/eapi/Common.rb:14
+msgctxt "EAPI_Common"
+msgid "Exit..."
+msgstr "終了..."
+
+#: ../src/eapi/Common.rb:16
+msgctxt "EAPI_Common"
+msgid "Hide program in Tray"
+msgstr "プログラムをトレイに隠す"
+
+#: ../src/eapi/Common.rb:16 ../src/scenes/Account.rb:657 ../src/scenes/Authentication.rb:23 ../src/scenes/Authentication.rb:25 ../src/scenes/ForgotPassword.rb:31 ../src/scenes/Loading.rb:383
+msgid "Exit"
+msgstr "終了"
+
+#: ../src/eapi/Common.rb:87
+msgctxt "EAPI_Common"
+msgid "Enter the command to execute"
+msgstr "実行するコマンドを入力"
+
+#: ../src/eapi/Common.rb:88
+msgctxt "EAPI_Common"
+msgid "Output"
+msgstr "出力"
+
+#: ../src/eapi/Common.rb:89
+msgctxt "EAPI_Common"
+msgid "Execute"
+msgstr "実行"
+
+#: ../src/eapi/Common.rb:95
+msgctxt "EAPI_Common"
+msgid "Disable auto clear input"
+msgstr "入力の自動クリアを無効にする"
+
+#: ../src/eapi/Common.rb:97
+msgctxt "EAPI_Common"
+msgid "Enable auto clear input"
+msgstr "入力の自動クリアを有効にする"
+
+#: ../src/eapi/Common.rb:102 ../src/eapi/Common.rb:116 ../src/eapi/Common.rb:134
+msgctxt "EAPI_Common"
+msgid "Disabled"
+msgstr "無効"
+
+#: ../src/eapi/Common.rb:105 ../src/eapi/Common.rb:119 ../src/eapi/Common.rb:131
+msgctxt "EAPI_Common"
+msgid "Enabled"
+msgstr "有効"
+
+#: ../src/eapi/Common.rb:109
+msgctxt "EAPI_Common"
+msgid "Disable auto clear output"
+msgstr "出力の自動クリアを無効にする"
+
+#: ../src/eapi/Common.rb:111
+msgctxt "EAPI_Common"
+msgid "Enable auto clear output"
+msgstr "出力の自動クリアを有効にする"
+
+#: ../src/eapi/Common.rb:124
+msgctxt "EAPI_Common"
+msgid "Enable source in output"
+msgstr "出力にソースを含めるを有効にする"
+
+#: ../src/eapi/Common.rb:126
+msgctxt "EAPI_Common"
+msgid "Disable source in output"
+msgstr "出力にソースを含めるを無効にする"
+
+#: ../src/eapi/Common.rb:138
+msgctxt "EAPI_Common"
+msgid "Load last code"
+msgstr "最後のコードを読み込む"
+
+#: ../src/eapi/Common.rb:142
+msgctxt "EAPI_Common"
+msgid "Last codes"
+msgstr "最後のコード"
+
+#: ../src/eapi/Common.rb:188
+msgctxt "EAPI_Common"
+msgid "Are you sure you want to exit console?"
+msgstr "コンソールを終了してもよろしいですか？"
+
+#: ../src/eapi/Common.rb:204
+msgctxt "EAPI_Common"
+msgid "This account is archived"
+msgstr "このアカウントはアーカイブされています"
+
+#: ../src/eapi/Common.rb:216
+msgctxt "EAPI_Common"
+msgid "Open user's blog"
+msgstr "ユーザーのブログを開く"
+
+#: ../src/eapi/Common.rb:216
+msgctxt "EAPI_Common"
+msgid "Visiting card"
+msgstr "名刺"
+
+#: ../src/eapi/Common.rb:216
+msgctxt "EAPI_Common"
+msgid "Write a private message"
+msgstr "プライベートメッセージを書く"
+
+#: ../src/eapi/Common.rb:216
+msgctxt "EAPI_Common"
+msgid "badges of this user"
+msgstr "このユーザーのバッジ"
+
+#: ../src/eapi/Common.rb:219
+msgctxt "EAPI_Common"
+msgid "Remove from contacts' list"
+msgstr "連絡先リストから削除"
+
+#: ../src/eapi/Common.rb:221
+msgctxt "EAPI_Common"
+msgid "Add to contacts' list"
+msgstr "連絡先リストに追加"
+
+#: ../src/eapi/Common.rb:224
+msgctxt "EAPI_Common"
+msgid "Unfollow feed"
+msgstr "フィードのフォローを解除"
+
+#: ../src/eapi/Common.rb:226
+msgctxt "EAPI_Common"
+msgid "Follow feed"
+msgstr "フィードをフォロー"
+
+#: ../src/eapi/Common.rb:240
+msgctxt "EAPI_Common"
+msgid "Unset ringtone"
+msgstr "着信音を解除"
+
+#: ../src/eapi/Common.rb:242
+msgctxt "EAPI_Common"
+msgid "Set ringtone"
+msgstr "着信音を設定"
+
+#: ../src/eapi/Common.rb:244
+msgctxt "EAPI_Common"
+msgid "Call this user"
+msgstr "このユーザーをかける"
+
+#: ../src/eapi/Common.rb:245
+msgctxt "EAPI_Common"
+msgid "Show feed"
+msgstr "フィードを表示"
+
+#: ../src/eapi/Common.rb:247
+msgctxt "EAPI_Common"
+msgid "Monitor when this user becomes online"
+msgstr "このユーザーがオンラインになったときに通知"
+
+#: ../src/eapi/Common.rb:249
+msgctxt "EAPI_Common"
+msgid "Do not monitor this user"
+msgstr "このユーザーの監視をやめる"
+
+#: ../src/eapi/Common.rb:253
+msgctxt "EAPI_Common"
+msgid "Ban"
+msgstr "禁止"
+
+#: ../src/eapi/Common.rb:255
+msgctxt "EAPI_Common"
+msgid "Unban"
+msgstr "禁止を解除"
+
+#: ../src/eapi/Common.rb:308
+msgctxt "EAPI_Common"
+msgid "Are you sure you want to delete this contact?"
+msgstr "この連絡先を削除してもよろしいですか？"
+
+#: ../src/eapi/Common.rb:320
+msgctxt "EAPI_Common"
+msgid "Feed unfollowed"
+msgstr "フィードのフォローを解除しました"
+
+#: ../src/eapi/Common.rb:322
+msgctxt "EAPI_Common"
+msgid "Feed followed"
+msgstr "フィードをフォローしました"
+
+#: ../src/eapi/Common.rb:334
+msgctxt "EAPI_Common"
+msgid "Ringtone removed"
+msgstr "着信音が削除されました"
+
+#: ../src/eapi/Common.rb:337
+msgctxt "EAPI_Common"
+msgid "Select ringtone for user %{user}"
+msgstr "ユーザー%{user}の着信音を選択"
+
+#: ../src/eapi/Common.rb:340
+msgctxt "EAPI_Common"
+msgid "Ringtone changed"
+msgstr "着信音が変更されました"
+
+#: ../src/eapi/Common.rb:350
+msgctxt "EAPI_Common"
+msgid "Notify me one time when this user becomes online"
+msgstr "このユーザーがオンラインになったとき、一度だけ通知"
+
+#: ../src/eapi/Common.rb:350
+msgctxt "EAPI_Common"
+msgid "Notify me whenever this user becomes online"
+msgstr "このユーザーがオンラインになるたびに通知"
+
+#: ../src/eapi/Common.rb:351
+msgctxt "EAPI_Common"
+msgid "Online monitor"
+msgstr "オンライン監視"
+
+#: ../src/eapi/Common.rb:357
+msgctxt "EAPI_Common"
+msgid "This user is now monitored"
+msgstr "このユーザーは監視されています"
+
+#: ../src/eapi/Common.rb:365
+msgctxt "EAPI_Common"
+msgid "This user is no longer monitored"
+msgstr "このユーザーの監視を停止しました"
+
+#: ../src/eapi/Common.rb:439
+msgctxt "EAPI_Common"
+msgid "There is nothing new."
+msgstr "新しいものはありません。"
+
+#: ../src/eapi/Common.rb:504
+msgctxt "EAPI_Common"
+msgid "Send"
+msgstr "送信"
+
+#: ../src/eapi/Common.rb:504
+msgctxt "EAPI_Common"
+msgid "Describe the found error"
+msgstr "見つかったエラーを説明してください"
+
+#: ../src/eapi/Common.rb:518
+msgctxt "EAPI_Common"
+msgid "Sent."
+msgstr "送信されました。"
+
+#: ../src/eapi/Common.rb:535 ../src/eapi/Common.rb:583 ../src/scenes/Account.rb:355 ../src/scenes/Account.rb:392 ../src/scenes/Account.rb:540 ../src/scenes/Blog.rb:735 ../src/scenes/Contacts.rb:27 ../src/scenes/Contacts.rb:127 ../src/scenes/Contacts.rb:160
+#: ../src/scenes/Forum.rb:1189 ../src/scenes/Login.rb:212 ../src/scenes/Messages.rb:1062 ../src/scenes/Users.rb:13
+msgid "Database Error"
+msgstr "データベースエラー"
+
+#: ../src/eapi/Common.rb:539 ../src/scenes/Account.rb:358 ../src/scenes/Account.rb:395 ../src/scenes/Account.rb:542 ../src/scenes/Blog.rb:737 ../src/scenes/Contacts.rb:31 ../src/scenes/Contacts.rb:130 ../src/scenes/Contacts.rb:163 ../src/scenes/Forum.rb:1191
+#: ../src/scenes/Messages.rb:1066 ../src/scenes/Users.rb:17
+msgid "Token expired"
+msgstr "トークンの有効期限が切れました"
+
+#: ../src/eapi/Common.rb:551
+msgctxt "EAPI_Common"
+msgid "Empty list"
+msgstr "リストが空です"
+
+#: ../src/eapi/Common.rb:558
+msgctxt "EAPI_Common"
+msgid "Select contact"
+msgstr "連絡先を選択"
+
+#: ../src/eapi/Common.rb:589
+msgctxt "EAPI_Common"
+msgid "User"
+msgstr "ユーザー"
+
+#: ../src/eapi/Common.rb:608
+msgctxt "EAPI_Common"
+msgid "Gender"
+msgstr "性別"
+
+#: ../src/eapi/Common.rb:610 ../src/scenes/Account.rb:122
+msgid "Female"
+msgstr "女性"
+
+#: ../src/eapi/Common.rb:612
+msgid "male"
+msgstr "男性"
+
+#: ../src/eapi/Common.rb:624
+msgctxt "EAPI_Common"
+msgid "Age"
+msgstr "年齢"
+
+#: ../src/eapi/Common.rb:627
+msgctxt "EAPI_Common"
+msgid "Location"
+msgstr "場所"
+
+#: ../src/eapi/Common.rb:641
+msgctxt "EAPI_Common_female"
+msgid "Last seen"
+msgstr "最終ログイン"
+
+#: ../src/eapi/Common.rb:643
+msgctxt "EAPI_Common_male"
+msgid "Last seen"
+msgstr "最終ログイン"
+
+#: ../src/eapi/Common.rb:645
+msgctxt "EAPI_Common"
+msgid "Last seen"
+msgstr "最終ログイン"
+
+#: ../src/eapi/Common.rb:648
+msgctxt "EAPI_Common"
+msgid "User has a blog"
+msgstr "ユーザーはブログを持っています"
+
+#: ../src/eapi/Common.rb:649
+msgctxt "EAPI_Common"
+msgid "Knows %{count} user"
+msgid_plural "Knows %{count} users"
+msgstr[0] "%{count}人のユーザーを知っています"
+
+#: ../src/eapi/Common.rb:651
+msgctxt "EAPI_Common"
+msgid "Known by %{count} user"
+msgid_plural "Known by %{count} users"
+msgstr[0] "%{count}人のユーザーに知られています"
+
+#: ../src/eapi/Common.rb:653
+msgctxt "EAPI_Common_female"
+msgid "Known by %{count} user"
+msgid_plural "Known by %{count} users"
+msgstr[0] "%{count}人のユーザーに知られています"
+
+#: ../src/eapi/Common.rb:655
+msgctxt "EAPI_Common_male"
+msgid "Known by %{count} user"
+msgid_plural "Known by %{count} users"
+msgstr[0] "%{count}人のユーザーに知られています"
+
+#: ../src/eapi/Common.rb:658
+msgctxt "EAPI_Common"
+msgid "Forum posts"
+msgstr "フォーラム投稿"
+
+#: ../src/eapi/Common.rb:659
+msgctxt "EAPI_Common"
+msgid "Polls answered"
+msgstr "回答した投票"
+
+#: ../src/eapi/Common.rb:669
+msgctxt "EAPI_Common"
+msgid "Used version"
+msgstr "使用バージョン"
+
+#: ../src/eapi/Common.rb:670
+msgctxt "EAPI_Common"
+msgid "Registered"
+msgstr "登録日"
+
+#: ../src/eapi/Common.rb:678
+msgctxt "EAPI_Common"
+msgid "Visiting card of %{user}:"
+msgstr "%{user}の名刺："
+
+#: ../src/eapi/Common.rb:692
+msgctxt "EAPI_Common"
+msgid "License agreement"
+msgstr "ライセンス契約"
+
+#: ../src/eapi/Common.rb:693
+msgctxt "EAPI_Common"
+msgid "Terms and Conditions"
+msgstr "利用規約"
+
+#: ../src/eapi/Common.rb:694
+msgctxt "EAPI_Common"
+msgid "Privacy Policy"
+msgstr "プライバシーポリシー"
+
+#: ../src/eapi/Common.rb:695
+msgctxt "EAPI_Common"
+msgid "I do not accept, exit"
+msgstr "同意せず、終了"
+
+#: ../src/eapi/Common.rb:695
+msgctxt "EAPI_Common"
+msgid "I accept Elten license agreement, Terms and Conditions and Privacy Policy"
+msgstr "エルテンのライセンス契約、利用規約、プライバシーポリシーに同意します"
+
+#: ../src/eapi/Common.rb:713
+msgctxt "EAPI_Common"
+msgid "Do you accept Elten license agreement, terms and conditions and privacy policy?"
+msgstr "エルテンのライセンス契約、利用規約、プライバシーポリシーに同意しますか？"
+
+#: ../src/eapi/Common.rb:734
+msgctxt "EAPI_Common"
+msgid "You are trying to play a midi file. In order to play such files, Elten needs an  external base of instruments. Do you want to download the base from the server  now? It may take several minutes."
+msgstr "MIDIファイルを再生しようとしています。これらのファイルを再生するには、エルテンは外部の楽器ベースが必要です。今サーバーからベースをダウンロードしますか？数分かかる場合があります。"
+
+#: ../src/eapi/Common.rb:735
+msgctxt "EAPI_Common"
+msgid "Please wait, the soundfont is being downloaded. It may take a while."
+msgstr "お待ちください、サウンドフォントをダウンロード中です。しばらく時間がかかる場合があります。"
+
+#: ../src/eapi/Common.rb:737
+msgctxt "EAPI_Common"
+msgid "Soundfont downloaded succesfully."
+msgstr "サウンドフォントのダウンロードが完了しました。"
+
+#: ../src/eapi/Common.rb:930
+msgctxt "EAPI_Common"
+msgid "In order to use HRTF functionality, Elten needs to download Phonon library. Would you like to download it now?"
+msgstr "HRTF機能を使用するには、エルテンはPhononライブラリをダウンロードする必要があります。今ダウンロードしますか？"
+
+#: ../src/eapi/Common.rb:954
+msgctxt "EAPI_Common"
+msgid "Courier"
+msgstr "クーリエ"
+
+#: ../src/eapi/Common.rb:956
+msgctxt "EAPI_Common"
+msgid "Audiophile"
+msgstr "オーディオファイル"
+
+#: ../src/eapi/Common.rb:958
+msgctxt "EAPI_Common"
+msgid "Scribe"
+msgstr "スクライブ"
+
+#: ../src/eapi/Common.rb:960
+msgctxt "EAPI_Common"
+msgid "Director"
+msgstr "ディレクター"
+
+#: ../src/eapi/Common.rb:962
+msgctxt "EAPI_Common"
+msgid "This feature requires %{package} premium package. Would you like to see the premium packages available?"
+msgstr "この機能を利用するには、%{package}プレミアムパッケージが必要です。利用可能なプレミアムパッケージを表示しますか？"
+
+#: ../src/eapi/Common.rb:1064
+msgid "Function not supported on this platform"
+msgstr "このプラットフォームではサポートされていない機能です"
+
+#: ../src/eapi/Common.rb:1091
+msgctxt "EAPI_Common"
+msgid "Compressing..."
+msgstr "圧縮中..."
+
+#: ../src/eapi/Common.rb:1230
+msgctxt "EAPI_Common"
+msgid "Save"
+msgstr "保存"
+
+#: ../src/eapi/Common.rb:1230
+msgctxt "EAPI_Common"
+msgid "Play"
+msgstr "再生"
+
+#: ../src/eapi/Common.rb:1234
+msgctxt "EAPI_Common"
+msgid "Where do you want to save this file?"
+msgstr "このファイルをどこに保存しますか？"
+
+#: ../src/eapi/Common.rb:1238
+msgctxt "EAPI_Common"
+msgid "The attachment has been downloaded."
+msgstr "添付ファイルがダウンロードされました。"
+
+#: ../src/eapi/Common.rb:1254 ../src/eapi/QuickActions.rb:73
+msgctxt "EAPI_Common"
+msgid "Message"
+msgstr "メッセージ"
+
+#: ../src/eapi/Common.rb:1255
+msgctxt "EAPI_Common"
+msgid "Users liking this message"
+msgstr "このメッセージを「いいね！」したユーザー"
+
+#: ../src/eapi/Common.rb:1256
+msgctxt "EAPI_Common"
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/eapi/Controls.rb:105 ../src/eapi/Controls.rb:107 ../src/eapi/Controls.rb:1044 ../src/eapi/Controls.rb:2643
+msgid "Context menu"
+msgstr "コンテキストメニュー"
+
+#: ../src/eapi/Controls.rb:414
+msgctxt "EAPI_Form"
+msgid "Press up or down arrow to select contact"
+msgstr "上下矢印キーで連絡先を選択"
+
+#: ../src/eapi/Controls.rb:416
+msgctxt "EAPI_Form"
+msgid "Select contact"
+msgstr "連絡先を選択"
+
+#: ../src/eapi/Controls.rb:438
+msgctxt "EAPI_Form"
+msgid "User does not exist"
+msgstr "ユーザーが存在しません"
+
+#: ../src/eapi/Controls.rb:605
+msgctxt "EAPI_Form"
+msgid "Opening a link..."
+msgstr "リンクを開いています..."
+
+#: ../src/eapi/Controls.rb:649 ../src/eapi/Controls.rb:656 ../src/eapi/Controls.rb:680
+msgctxt "EAPI_Form"
+msgid "End of line"
+msgstr "行末"
+
+#: ../src/eapi/Controls.rb:915
+msgctxt "EAPI_Form"
+msgid "Format"
+msgstr "フォーマット"
+
+#: ../src/eapi/Controls.rb:916 ../src/eapi/Controls.rb:1795
+msgctxt "EAPI_Form"
+msgid "Bold"
+msgstr "太字"
+
+#: ../src/eapi/Controls.rb:921 ../src/eapi/Controls.rb:1797
+msgctxt "EAPI_Form"
+msgid "Italic"
+msgstr "斜体"
+
+#: ../src/eapi/Controls.rb:926 ../src/eapi/Controls.rb:1799
+msgctxt "EAPI_Form"
+msgid "Underline"
+msgstr "下線"
+
+#: ../src/eapi/Controls.rb:931
+msgctxt "EAPI_Form"
+msgid "Heading"
+msgstr "見出し"
+
+#: ../src/eapi/Controls.rb:933 ../src/eapi/Controls.rb:1801
+msgctxt "EAPI_Form"
+msgid "Heading level %{level}"
+msgstr "見出しレベル %{level}"
+
+#: ../src/eapi/Controls.rb:958
+msgctxt "EAPI_Form"
+msgid "Insert"
+msgstr "挿入"
+
+#: ../src/eapi/Controls.rb:959 ../src/eapi/Controls.rb:1803
+msgctxt "EAPI_Form"
+msgid "Link"
+msgstr "リンク"
+
+#: ../src/eapi/Controls.rb:962
+msgctxt "EAPI_Form"
+msgid "URL"
+msgstr "URL"
+
+#: ../src/eapi/Controls.rb:963
+msgctxt "EAPI_Form"
+msgid "Label"
+msgstr "ラベル"
+
+#: ../src/eapi/Controls.rb:964
+msgctxt "EAPI_Form"
+msgid "Add"
+msgstr "追加"
+
+#: ../src/eapi/Controls.rb:987
+msgctxt "EAPI_Form"
+msgid "Read from cursor"
+msgstr "カーソル位置から読み上げ"
+
+#: ../src/eapi/Controls.rb:990
+msgctxt "EAPI_Form"
+msgid "Read line"
+msgstr "行を読み上げ"
+
+#: ../src/eapi/Controls.rb:993 ../src/eapi/Controls.rb:2613
+msgctxt "EAPI_Form"
+msgid "Copy"
+msgstr "コピー"
+
+#: ../src/eapi/Controls.rb:997
+msgctxt "EAPI_Form"
+msgid "Cut"
+msgstr "カット"
+
+#: ../src/eapi/Controls.rb:1000 ../src/eapi/Controls.rb:2616
+msgctxt "EAPI_Form"
+msgid "Paste"
+msgstr "ペースト"
+
+#: ../src/eapi/Controls.rb:1003
+msgctxt "EAPI_Form"
+msgid "Undo"
+msgstr "元に戻す"
+
+#: ../src/eapi/Controls.rb:1006
+msgctxt "EAPI_Form"
+msgid "Redo"
+msgstr "やり直し"
+
+#: ../src/eapi/Controls.rb:1009
+msgctxt "EAPI_Form"
+msgid "Spell check"
+msgstr "スペルチェック"
+
+#: ../src/eapi/Controls.rb:1014
+msgctxt "EAPI_Form"
+msgid "Load last text"
+msgstr "最後のテキストを読み込む"
+
+#: ../src/eapi/Controls.rb:1025
+msgctxt "EAPI_Form"
+msgid "Find"
+msgstr "検索"
+
+#: ../src/eapi/Controls.rb:1028
+msgctxt "EAPI_Form"
+msgid "Quick translation"
+msgstr "クイック翻訳"
+
+#: ../src/eapi/Controls.rb:1033
+msgctxt "EAPI_Form"
+msgid "Translate"
+msgstr "翻訳"
+
+#: ../src/eapi/Controls.rb:1044 ../src/eapi/Controls.rb:1614
+msgctxt "EAPI_Form"
+msgid "Edit box"
+msgstr "編集ボックス"
+
+#: ../src/eapi/Controls.rb:1045 ../src/eapi/Controls.rb:2638
+msgctxt "EAPI_Form"
+msgid "Edit"
+msgstr "編集"
+
+#: ../src/eapi/Controls.rb:1064
+msgctxt "EAPI_Form"
+msgid "Language"
+msgstr "言語"
+
+#: ../src/eapi/Controls.rb:1065
+msgctxt "EAPI_Form"
+msgid "Replace"
+msgstr "置換"
+
+#: ../src/eapi/Controls.rb:1096
+msgctxt "EAPI_Form"
+msgid "Use custom text"
+msgstr "カスタムテキストを使用"
+
+#: ../src/eapi/Controls.rb:1096
+msgctxt "EAPI_Form"
+msgid "Ignore"
+msgstr "無視"
+
+#: ../src/eapi/Controls.rb:1135
+msgctxt "EAPI_Form"
+msgid "%{count} word replaced"
+msgid_plural "%{count} words replaced"
+msgstr[0] "%{count}個の単語を置換しました"
+
+#: ../src/eapi/Controls.rb:1145
+msgctxt "EAPI_Form"
+msgid "copied"
+msgstr "コピーしました"
+
+#: ../src/eapi/Controls.rb:1151
+msgctxt "EAPI_Form"
+msgid "Cut out"
+msgstr "カットしました"
+
+#: ../src/eapi/Controls.rb:1156
+msgctxt "EAPI_Form"
+msgid "pasted"
+msgstr "ペーストしました"
+
+#: ../src/eapi/Controls.rb:1164
+msgctxt "EAPI_Form"
+msgid "undone"
+msgstr "元に戻しました"
+
+#: ../src/eapi/Controls.rb:1172
+msgctxt "EAPI_Form"
+msgid "Repeated"
+msgstr "繰り返しました"
+
+#: ../src/eapi/Controls.rb:1175
+msgctxt "EAPI_Form"
+msgid "Enter a phrase to look for"
+msgstr "検索するフレーズを入力してください"
+
+#: ../src/eapi/Controls.rb:1182
+msgctxt "EAPI_Form"
+msgid "No match found."
+msgstr "一致するものが見つかりませんでした。"
+
+#: ../src/eapi/Controls.rb:1615
+msgctxt "EAPI_Form"
+msgid "Text"
+msgstr "テキスト"
+
+#: ../src/eapi/Controls.rb:1616
+msgctxt "EAPI_Form"
+msgid "Media"
+msgstr "メディア"
+
+#: ../src/eapi/Controls.rb:1805
+msgctxt "EAPI_Form"
+msgid "List"
+msgstr "リスト"
+
+#: ../src/eapi/Controls.rb:1807
+msgctxt "EAPI_Form"
+msgid "List item"
+msgstr "リスト項目"
+
+#: ../src/eapi/Controls.rb:1809
+msgctxt "EAPI_Form"
+msgid "Frame"
+msgstr "フレーム"
+
+#: ../src/eapi/Controls.rb:1833
+msgctxt "EAPI_Form"
+msgid "Use h or numbers from 1 to 6 to navigate to the next header"
+msgstr "次のヘッダーに移動するには、h または 1 から 6 の数字を使用してください"
+
+#: ../src/eapi/Controls.rb:1834
+msgctxt "EAPI_Form"
+msgid "Use k to navigate to the next link"
+msgstr "次のリンクに移動するには、k を使用してください"
+
+#: ../src/eapi/Controls.rb:1835
+msgctxt "EAPI_Form"
+msgid "Use i to navigate to the next list item"
+msgstr "次のリスト項目に移動するには、i を使用してください"
+
+#: ../src/eapi/Controls.rb:1836
+msgctxt "EAPI_Form"
+msgid "Use the above shortcuts with shift to navigate to the previous items"
+msgstr "上記のショートカットを Shift キーと一緒に使用して、前の項目に移動します"
+
+#: ../src/eapi/Controls.rb:1997
+msgctxt "EAPI_Form"
+msgid "All tags"
+msgstr "すべてのタグ"
+
+#: ../src/eapi/Controls.rb:2118
+msgctxt "EAPI_Common"
+msgid "Ticked"
+msgstr "選択済み"
+
+#: ../src/eapi/Controls.rb:2119
+msgctxt "EAPI_Common"
+msgid "Unticked"
+msgstr "未選択"
+
+#: ../src/eapi/Controls.rb:2148 ../src/eapi/Controls.rb:2390
+msgctxt "EAPI_Form"
+msgid "Checked"
+msgstr "チェック済み"
+
+#: ../src/eapi/Controls.rb:2151
+msgctxt "EAPI_Form"
+msgid "You can check only %{count} item"
+msgid_plural "You can check only %{count} items"
+msgstr[0] "チェックできる項目は %{count} 個のみです"
+
+#: ../src/eapi/Controls.rb:2158
+msgctxt "EAPI_Form"
+msgid "Unchecked"
+msgstr "未チェック"
+
+#: ../src/eapi/Controls.rb:2203
+msgctxt "EAPI_Form"
+msgid "Multiselection list"
+msgstr "複数選択リスト"
+
+#: ../src/eapi/Controls.rb:2212
+msgctxt "EAPI_Common"
+msgid "Checked"
+msgstr "チェック済み"
+
+#: ../src/eapi/Controls.rb:2213
+msgctxt "EAPI_Common"
+msgid "Unchecked"
+msgstr "未チェック"
+
+#: ../src/eapi/Controls.rb:2221
+msgctxt "EAPI_Form"
+msgid "Empty list"
+msgstr "リストが空です"
+
+#: ../src/eapi/Controls.rb:2306
+msgctxt "EAPI_Form"
+msgid "Use space to select or unselect items"
+msgstr "スペースキーを使用して項目を選択または選択解除します"
+
+#: ../src/eapi/Controls.rb:2309
+msgctxt "EAPI_Form"
+msgid "Use shift with up/down arrows to filter content by tags"
+msgstr "Shiftキーと上下矢印キーを使用して、タグでコンテンツをフィルタリングします"
+
+#: ../src/eapi/Controls.rb:2311
+msgctxt "EAPI_Form"
+msgid "Press CTRL + up arrow to read item index"
+msgstr "Ctrl + 上矢印キーを押して、項目のインデックスを読み上げます"
+
+#: ../src/eapi/Controls.rb:2312
+msgctxt "EAPI_Form"
+msgid "Press CTRL + down arrow to read count of items"
+msgstr "Ctrl + 下矢印キーを押して、項目の数を読み上げます"
+
+#: ../src/eapi/Controls.rb:2341
+msgctxt "EAPI_Form"
+msgid "Button"
+msgstr "ボタン"
+
+#: ../src/eapi/Controls.rb:2387
+msgctxt "EAPI_Form"
+msgid "unchecked"
+msgstr "未チェック"
+
+#: ../src/eapi/Controls.rb:2407
+msgctxt "EAPI_Form"
+msgid "Tickbox"
+msgstr "チェックボックス"
+
+#: ../src/eapi/Controls.rb:2410
+msgctxt "EAPI_Form"
+msgid "unticked"
+msgstr "チェックなし"
+
+#: ../src/eapi/Controls.rb:2412
+msgctxt "EAPI_Form"
+msgid "ticked"
+msgstr "チェック"
+
+#: ../src/eapi/Controls.rb:2480
+msgctxt "EAPI_Form"
+msgid "Documents"
+msgstr "ドキュメント"
+
+#: ../src/eapi/Controls.rb:2480
+msgctxt "EAPI_Form"
+msgid "Music"
+msgstr "音楽"
+
+#: ../src/eapi/Controls.rb:2480
+msgctxt "EAPI_Form"
+msgid "Desktop"
+msgstr "デスクトップ"
+
+#: ../src/eapi/Controls.rb:2605
+msgctxt "EAPI_Form"
+msgid "Rename"
+msgstr "名前の変更"
+
+#: ../src/eapi/Controls.rb:2622
+msgctxt "EAPI_Form"
+msgid "New folder"
+msgstr "新しいフォルダー"
+
+#: ../src/eapi/Controls.rb:2625
+msgctxt "EAPI_Form"
+msgid "Folder name"
+msgstr "フォルダー名"
+
+#: ../src/eapi/Controls.rb:2629
+msgctxt "EAPI_Form"
+msgid "The folder has been created."
+msgstr "フォルダーが作成されました"
+
+#: ../src/eapi/Controls.rb:2636
+msgctxt "EAPI_Form"
+msgid "File"
+msgstr "ファイル"
+
+#: ../src/eapi/Controls.rb:2640
+msgctxt "EAPI_Form"
+msgid "Create"
+msgstr "作成"
+
+#: ../src/eapi/Controls.rb:2643
+msgctxt "EAPI_Form"
+msgid "Files Tree"
+msgstr "ファイルツリー"
+
+#: ../src/eapi/Controls.rb:2757
+msgctxt "EAPI_Form"
+msgid "Pasted"
+msgstr "貼り付けました"
+
+#: ../src/eapi/Controls.rb:2763
+msgctxt "EAPI_Form"
+msgid "Copied"
+msgstr "コピーしました"
+
+#: ../src/eapi/Controls.rb:2769
+msgctxt "EAPI_Form"
+msgid "New file name"
+msgstr "新しいファイル名"
+
+#: ../src/eapi/Controls.rb:2773
+msgctxt "EAPI_Form"
+msgid "The file name has been changed."
+msgstr "ファイル名が変更されました"
+
+#: ../src/eapi/Controls.rb:2780
+msgctxt "EAPI_Form"
+msgid "Do you really want to delete %{filename}?"
+msgstr "本当に%{filename}を削除しますか？"
+
+#: ../src/eapi/Controls.rb:2787
+msgctxt "EAPI_Form"
+msgid "Deleted"
+msgstr "削除しました"
+
+#: ../src/eapi/Controls.rb:3050
+msgctxt "EAPI_Form"
+msgid "Choose a path"
+msgstr "パスを選択"
+
+#: ../src/eapi/Controls.rb:3176
+msgctxt "EAPI_Form"
+msgid "Use SHIFT with left/right arrows to select the column you want to navigate by"
+msgstr "シフトキーと左右矢印キーを使用して、ナビゲートする列を選択します"
+
+#: ../src/eapi/Controls.rb:3214 ../src/eapi/Controls.rb:3224
+msgctxt "EAPI_Common"
+msgid "This file cannot be played."
+msgstr "このファイルは再生できません"
+
+#: ../src/eapi/Controls.rb:3324 ../src/eapi/Controls.rb:4637
+msgctxt "EAPI_Form"
+msgid "Hour"
+msgstr "時間"
+
+#: ../src/eapi/Controls.rb:3325 ../src/eapi/Controls.rb:4638
+msgctxt "EAPI_Form"
+msgid "Minute"
+msgstr "分"
+
+#: ../src/eapi/Controls.rb:3326 ../src/eapi/Controls.rb:4639
+msgctxt "EAPI_Form"
+msgid "Second"
+msgstr "秒"
+
+#: ../src/eapi/Controls.rb:3327
+msgctxt "EAPI_Form"
+msgid "Jump"
+msgstr "ジャンプ"
+
+#: ../src/eapi/Controls.rb:3384
+msgctxt "EAPI_Form"
+msgid "Copy original stream"
+msgstr "元のストリームをコピー"
+
+#: ../src/eapi/Controls.rb:3390
+msgctxt "EAPI_Form"
+msgid "Destination"
+msgstr "保存先"
+
+#: ../src/eapi/Controls.rb:3391
+msgctxt "EAPI_Form"
+msgid "File format"
+msgstr "ファイル形式"
+
+#: ../src/eapi/Controls.rb:3392
+msgctxt "EAPI_Form"
+msgid "File name"
+msgstr "ファイル名"
+
+#: ../src/eapi/Controls.rb:3497
+msgctxt "EAPI_Form"
+msgid "Play/pause"
+msgstr "再生/一時停止"
+
+#: ../src/eapi/Controls.rb:3510
+msgctxt "EAPI_Form"
+msgid "Get sound position"
+msgstr "サウンドの位置を取得"
+
+#: ../src/eapi/Controls.rb:3523
+msgctxt "EAPI_Form"
+msgid "Get sound duration"
+msgstr "サウンドの長さを取得"
+
+#: ../src/eapi/Controls.rb:3532
+msgctxt "EAPI_Form"
+msgid "Track info"
+msgstr "トラック情報"
+
+#: ../src/eapi/Controls.rb:3536 ../src/eapi/Controls.rb:4429
+msgctxt "EAPI_Form"
+msgid "Title"
+msgstr "タイトル"
+
+#: ../src/eapi/Controls.rb:3537 ../src/eapi/Controls.rb:4430
+msgctxt "EAPI_Form"
+msgid "Artist"
+msgstr "アーティスト"
+
+#: ../src/eapi/Controls.rb:3538 ../src/eapi/Controls.rb:4431
+msgctxt "EAPI_Form"
+msgid "Album"
+msgstr "アルバム"
+
+#: ../src/eapi/Controls.rb:3539 ../src/eapi/Controls.rb:4432
+msgctxt "EAPI_Form"
+msgid "Track number"
+msgstr "トラック番号"
+
+#: ../src/eapi/Controls.rb:3540 ../src/eapi/Controls.rb:4433
+msgctxt "EAPI_Form"
+msgid "Copyright"
+msgstr "著作権"
+
+#: ../src/eapi/Controls.rb:3554
+msgctxt "EAPI_Form"
+msgid "Show chapters"
+msgstr "チャプターを表示"
+
+#: ../src/eapi/Controls.rb:3556 ../src/eapi/Controls.rb:4423
+msgctxt "EAPI_Form"
+msgid "Chapters"
+msgstr "チャプター"
+
+#: ../src/eapi/Controls.rb:3567
+msgctxt "EAPI_Form"
+msgid "This chapter has not been buffered yet"
+msgstr "このチャプターはまだバッファリングされていません"
+
+#: ../src/eapi/Controls.rb:3578
+msgctxt "EAPI_Form"
+msgid "Jump to position"
+msgstr "指定位置に移動"
+
+#: ../src/eapi/Controls.rb:3589
+msgctxt "EAPI_Form"
+msgid "Save file"
+msgstr "ファイルを保存"
+
+#: ../src/eapi/Controls.rb:3601
+msgctxt "EAPI_Form"
+msgid "Use spacebar to toggle pause"
+msgstr "スペースバーで一時停止を切り替えます"
+
+#: ../src/eapi/Controls.rb:3602
+msgctxt "EAPI_Form"
+msgid "Use left/right arrows to slide"
+msgstr "左右矢印キーで移動します"
+
+#: ../src/eapi/Controls.rb:3603
+msgctxt "EAPI_Form"
+msgid "Use up/down arrows to change playback volume"
+msgstr "上下矢印キーで再生音量を変更します"
+
+#: ../src/eapi/Controls.rb:3604
+msgctxt "EAPI_Form"
+msgid "Use SHIFT with left/right arrows to change panning"
+msgstr "シフトキーと左右矢印キーでパンを変更します"
+
+#: ../src/eapi/Controls.rb:3605
+msgctxt "EAPI_Form"
+msgid "Use SHIFT with up/down arrows to change pitch"
+msgstr "シフトキーと上下矢印キーでピッチを変更します"
+
+#: ../src/eapi/Controls.rb:3606
+msgctxt "EAPI_Form"
+msgid "Use CTRL with up/down arrows to change tempo"
+msgstr "コントロールキーと上下矢印キーでテンポを変更します"
+
+#: ../src/eapi/Controls.rb:3607
+msgctxt "EAPI_Form"
+msgid "Use backspace to return to the default settings"
+msgstr "バックスペイスキーでデフォルト設定に戻ります"
+
+#: ../src/eapi/Controls.rb:3608
+msgctxt "EAPI_Form"
+msgid "Use home or end to move to the beginning or ending of a track"
+msgstr "ホームキーまたはエンドキーでトラックの先頭または末尾に移動します"
+
+#: ../src/eapi/Controls.rb:3609
+msgctxt "EAPI_Form"
+msgid "Use page up or page down to navigate to the previous or next chapter"
+msgstr "ページアップキーまたはページダウンキーで前のチャプターまたは次のチャプターに移動します"
+
+#: ../src/eapi/Controls.rb:4190
+msgctxt "EAPI_Form"
+msgid "record"
+msgstr "録音"
+
+#: ../src/eapi/Controls.rb:4191 ../src/eapi/Controls.rb:4251 ../src/eapi/Controls.rb:4280
+msgctxt "EAPI_Form"
+msgid "Pause recording"
+msgstr "録音を一時停止"
+
+#: ../src/eapi/Controls.rb:4192
+msgctxt "EAPI_Form"
+msgid "Stop recording"
+msgstr "録音を停止"
+
+#: ../src/eapi/Controls.rb:4193
+msgctxt "EAPI_Form"
+msgid "Use existing file"
+msgstr "既存のファイルを使用"
+
+#: ../src/eapi/Controls.rb:4194
+msgctxt "EAPI_Form"
+msgid "Opus encoder settings"
+msgstr "Opusエンコーダー設定"
+
+#: ../src/eapi/Controls.rb:4195
+msgctxt "Conference"
+msgid "Edit metadata and chapters"
+msgstr "メタデータとチャプターを編集"
+
+#: ../src/eapi/Controls.rb:4196
+msgctxt "EAPI_Form"
+msgid "Play"
+msgstr "再生"
+
+#: ../src/eapi/Controls.rb:4197
+msgctxt "EAPI_Form"
+msgid "Encode and play"
+msgstr "エンコードして再生"
+
+#: ../src/eapi/Controls.rb:4198
+msgctxt "EAPI_Form"
+msgid "Delete recording"
+msgstr "録音を削除"
+
+#: ../src/eapi/Controls.rb:4199 ../src/eapi/Controls.rb:4640
+msgctxt "EAPI_Form"
+msgid "Ready"
+msgstr "準備完了"
+
+#: ../src/eapi/Controls.rb:4208 ../src/eapi/Controls.rb:4256
+msgctxt "EAPI_Form"
+msgid "Are you sure you want to delete the previous recording and create a new one?"
+msgstr "前の録音を削除して新しい録音を作成してもよろしいですか？"
+
+#: ../src/eapi/Controls.rb:4250
+msgctxt "EAPI_Form"
+msgid "Record again"
+msgstr "再度録音"
+
+#: ../src/eapi/Controls.rb:4257
+msgctxt "EAPI_Form"
+msgid "Select audio file"
+msgstr "音声ファイルを選択"
+
+#: ../src/eapi/Controls.rb:4260
+msgctxt "EAPI_Form"
+msgid "File selected"
+msgstr "ファイルが選択されました"
+
+#: ../src/eapi/Controls.rb:4270
+msgctxt "EAPI_Form"
+msgid "Recording preview"
+msgstr "録音プレビュー"
+
+#: ../src/eapi/Controls.rb:4284
+msgctxt "EAPI_Form"
+msgid "Resume recording"
+msgstr "録音を再開"
+
+#: ../src/eapi/Controls.rb:4290
+msgctxt "EAPI_Form"
+msgid "The encoder settings will not apply to the current record. Are you sure you want to continue?"
+msgstr "エンコーダー設定は現在の録音には適用されません。続行してもよろしいですか？"
+
+#: ../src/eapi/Controls.rb:4308
+msgctxt "EAPI_Form"
+msgid "Are you sure you want to delete recorded audio?"
+msgstr "録音した音声を削除してもよろしいですか？"
+
+#: ../src/eapi/Controls.rb:4329
+msgctxt "EAPI_Form"
+msgid "Low"
+msgstr "低い"
+
+#: ../src/eapi/Controls.rb:4330
+msgctxt "EAPI_Form"
+msgid "Lower"
+msgstr "より低い"
+
+#: ../src/eapi/Controls.rb:4331
+msgctxt "EAPI_Form"
+msgid "Standard"
+msgstr "標準"
+
+#: ../src/eapi/Controls.rb:4332
+msgctxt "EAPI_Form"
+msgid "Higher"
+msgstr "より高い"
+
+#: ../src/eapi/Controls.rb:4333
+msgctxt "EAPI_Form"
+msgid "High"
+msgstr "高い"
+
+#: ../src/eapi/Controls.rb:4334
+msgctxt "EAPI_Form"
+msgid "Max"
+msgstr "最大"
+
+#: ../src/eapi/Controls.rb:4341
+msgctxt "EAPI_Form"
+msgid "Custom"
+msgstr "カスタム"
+
+#: ../src/eapi/Controls.rb:4341
+msgctxt "EAPI_Form"
+msgid "Quality"
+msgstr "品質"
+
+#: ../src/eapi/Controls.rb:4342
+msgctxt "EAPI_Form"
+msgid "Bitrate"
+msgstr "ビットレート"
+
+#: ../src/eapi/Controls.rb:4343
+msgctxt "EAPI_Form"
+msgid "Frame size"
+msgstr "フレームサイズ"
+
+#: ../src/eapi/Controls.rb:4344
+msgctxt "EAPI_Form"
+msgid "Music profile"
+msgstr "音楽プロファイル"
+
+#: ../src/eapi/Controls.rb:4344
+msgctxt "EAPI_Form"
+msgid "Encoder profile"
+msgstr "エンコーダープロファイル"
+
+#: ../src/eapi/Controls.rb:4344
+msgctxt "EAPI_Form"
+msgid "Speech profile"
+msgstr "音声プロファイル"
+
+#: ../src/eapi/Controls.rb:4345
+msgctxt "EAPI_Form"
+msgid "Use variable bitrate"
+msgstr "可変ビットレートを使用"
+
+#: ../src/eapi/Controls.rb:4421
+msgctxt "EAPI_Form"
+msgid "Tags"
+msgstr "タグ"
+
+#: ../src/eapi/Controls.rb:4422
+msgctxt "EAPI_Form"
+msgid "Tag value"
+msgstr "タグの値"
+
+#: ../src/eapi/Controls.rb:4485 ../src/eapi/Controls.rb:4526
+msgctxt "EAPI_Form"
+msgid "Chapter name"
+msgstr "チャプター名"
+
+#: ../src/eapi/Controls.rb:4486
+msgctxt "EAPI_Form"
+msgid "Chapter time (hh:mm:ss.uuu)"
+msgstr "チャプター時間 (hh:mm:ss.uuu)"
+
+#: ../src/eapi/Controls.rb:4497
+msgctxt "EAPI_Form"
+msgid "Wrong time format, the proper format is two hours digits, colon, two minutes digits, colon, two seconds digits and, optionally, three milliseconds digits preceeded by dot"
+msgstr "時間形式が間違っています。正しい形式は、2桁の時間、コロン、2桁の分、コロン、2桁の秒、そしてオプションでドットの後に3桁のミリ秒です。"
+
+#: ../src/eapi/Controls.rb:4514
+msgctxt "EAPI_Form"
+msgid "Add new chapter manually"
+msgstr "新しいチャプターを手動で追加"
+
+#: ../src/eapi/Controls.rb:4515
+msgctxt "EAPI_Form"
+msgid "Add chapters with playback"
+msgstr "再生しながらチャプターを追加"
+
+#: ../src/eapi/Controls.rb:4517
+msgctxt "EAPI_Form"
+msgid "Chapters editor, use context menu to add chapters"
+msgstr "チャプターエディタ、チャプターを追加するにはコンテキストメニューを使用"
+
+#: ../src/eapi/Controls.rb:4521
+msgctxt "EAPI_Form"
+msgid "Add chapter here"
+msgstr "ここにチャプターを追加"
+
+#: ../src/eapi/Controls.rb:4549
+msgctxt "EAPI_Form"
+msgid "Edit chapter"
+msgstr "チャプターを編集"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "June"
+msgstr "６月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "July"
+msgstr "７月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "August"
+msgstr "８月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "September"
+msgstr "９月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "April"
+msgstr "４月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "November"
+msgstr "１１月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "December"
+msgstr "１２月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "February"
+msgstr "２月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "January"
+msgstr "１月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "October"
+msgstr "１０月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "May"
+msgstr "５月"
+
+#: ../src/eapi/Controls.rb:4628
+msgctxt "EAPI_Form"
+msgid "March"
+msgstr "３月"
+
+#: ../src/eapi/Controls.rb:4634 ../src/eapi/Controls.rb:4635 ../src/eapi/Controls.rb:4636 ../src/eapi/Controls.rb:4637 ../src/eapi/Controls.rb:4638 ../src/eapi/Controls.rb:4639 ../src/eapi/Controls.rb:4681 ../src/eapi/Controls.rb:4683 ../src/eapi/Controls.rb:4690
+#: ../src/eapi/Controls.rb:4701 ../src/eapi/Controls.rb:4708 ../src/eapi/Controls.rb:4710 ../src/eapi/Controls.rb:4717 ../src/eapi/Controls.rb:4719 ../src/eapi/Controls.rb:4726 ../src/eapi/Controls.rb:4728 ../src/eapi/Controls.rb:4737
+msgctxt "EAPI_Form"
+msgid "Not selected"
+msgstr "選択なし"
+
+#: ../src/eapi/Controls.rb:4634
+msgctxt "EAPI_Form"
+msgid "Year"
+msgstr "年"
+
+#: ../src/eapi/Controls.rb:4635
+msgctxt "EAPI_Form"
+msgid "Month"
+msgstr "月"
+
+#: ../src/eapi/Controls.rb:4636
+msgctxt "EAPI_Form"
+msgid "Day"
+msgstr "日"
+
+#: ../src/eapi/EltenSRV.rb:452
+msgctxt "EAPI_EltenSRV"
+msgid "Select a user"
+msgstr "ユーザーを選択"
+
+#: ../src/eapi/External.rb:37 ../src/eapi/External.rb:49
+msgctxt "EAPI_External"
+msgid "An error occurred while translating."
+msgstr "翻訳中にエラーが発生しました。"
+
+#: ../src/eapi/External.rb:113
+msgctxt "EAPI_External"
+msgid "source language"
+msgstr "元の言語"
+
+#: ../src/eapi/External.rb:113
+msgctxt "EAPI_External"
+msgid "recognize automatically"
+msgstr "自動認識"
+
+#: ../src/eapi/External.rb:118
+msgctxt "EAPI_External"
+msgid "destination language"
+msgstr "翻訳先の言語"
+
+#: ../src/eapi/External.rb:119
+msgctxt "EAPI_External"
+msgid "Translate"
+msgstr "翻訳"
+
+#: ../src/eapi/MainMenu.rb:22
+msgctxt "MainMenu"
+msgid "Menu"
+msgstr "メニュー"
+
+#: ../src/eapi/MainMenu.rb:38
+msgctxt "MainMenu"
+msgid "Quick &actions"
+msgstr "クイックアクション(&A)"
+
+#: ../src/eapi/MainMenu.rb:46
+msgctxt "MainMenu"
+msgid "&Community"
+msgstr "コミュニティ(&C)"
+
+#: ../src/eapi/MainMenu.rb:48
+msgctxt "MainMenu"
+msgid "&Messages"
+msgstr "メッセージ(&M)"
+
+#: ../src/eapi/MainMenu.rb:50
+msgctxt "MainMenu"
+msgid "&Blogs"
+msgstr "ブログ(&B)"
+
+#: ../src/eapi/MainMenu.rb:51
+msgctxt "MainMenu"
+msgid "&Forum"
+msgstr "フォーラム(&F)"
+
+#: ../src/eapi/MainMenu.rb:52
+msgctxt "MainMenu"
+msgid "&Conferences"
+msgstr "会議(&C)"
+
+#: ../src/eapi/MainMenu.rb:54
+msgctxt "MainMenu"
+msgid "No&tes"
+msgstr "ノート(&T)"
+
+#: ../src/eapi/MainMenu.rb:55
+msgctxt "MainMenu"
+msgid "What's &new?"
+msgstr "新着情報&N"
+
+#: ../src/eapi/MainMenu.rb:56
+msgctxt "MainMenu"
+msgid "Po&lls"
+msgstr "投票(&L)"
+
+#: ../src/eapi/MainMenu.rb:58
+msgctxt "MainMenu"
+msgid "&Users"
+msgstr "ユーザー(&U)"
+
+#: ../src/eapi/MainMenu.rb:60
+msgctxt "MainMenu"
+msgid "My &contacts"
+msgstr "連絡先(&C)"
+
+#: ../src/eapi/MainMenu.rb:61
+msgctxt "MainMenu"
+msgid "Users who a&dded me to contacts"
+msgstr "連絡先に追加したユーザー(&D)"
+
+#: ../src/eapi/MainMenu.rb:63
+msgctxt "MainMenu"
+msgid "Who is &online?"
+msgstr "誰がオンライン?&O"
+
+#: ../src/eapi/MainMenu.rb:64
+msgctxt "MainMenu"
+msgid "&badges"
+msgstr "バッジ(&B)"
+
+#: ../src/eapi/MainMenu.rb:65
+msgctxt "MainMenu"
+msgid "&Users list"
+msgstr "ユーザーリスト(&U)"
+
+#: ../src/eapi/MainMenu.rb:66
+msgctxt "MainMenu"
+msgid "Ad&mins and authors"
+msgstr "管理者と著者(&M)"
+
+#: ../src/eapi/MainMenu.rb:67
+msgctxt "MainMenu"
+msgid "User searc&h"
+msgstr "ユーザー検索(&H)"
+
+#: ../src/eapi/MainMenu.rb:68
+msgctxt "MainMenu"
+msgid "Recently &active users"
+msgstr "最近のアクティブユーザー(&A)"
+
+#: ../src/eapi/MainMenu.rb:69
+msgctxt "MainMenu"
+msgid "Recently &registered users"
+msgstr "最近の登録ユーザー(&R)"
+
+#: ../src/eapi/MainMenu.rb:70
+msgctxt "MainMenu"
+msgid "&Sponsors"
+msgstr "スポンサー(&S)"
+
+#: ../src/eapi/MainMenu.rb:73
+msgctxt "MainMenu"
+msgid "Call &history"
+msgstr "通話履歴(&H)"
+
+#: ../src/eapi/MainMenu.rb:74
+msgctxt "MainMenu"
+msgid "Premium packa&ges"
+msgstr "プレミアムパッケージ(&G)"
+
+#: ../src/eapi/MainMenu.rb:75
+msgctxt "MainMenu"
+msgid "Manage my &account"
+msgstr "アカウントを管理(&A)"
+
+#: ../src/eapi/MainMenu.rb:79
+msgctxt "MainMenu"
+msgid "&Programs"
+msgstr "プログラム(&P)"
+
+#: ../src/eapi/MainMenu.rb:84
+msgctxt "MainMenu"
+msgid "Programs installation"
+msgstr "プログラムのインストール"
+
+#: ../src/eapi/MainMenu.rb:86
+msgctxt "MainMenu"
+msgid "&Tools"
+msgstr "ツール(&T)"
+
+#: ../src/eapi/MainMenu.rb:87
+msgctxt "MainMenu"
+msgid "Program &settings"
+msgstr "プログラム設定(&S)"
+
+#: ../src/eapi/MainMenu.rb:88
+msgctxt "MainMenu"
+msgid "Soun&dthemes"
+msgstr "サウンドテーマ(&D)"
+
+#: ../src/eapi/MainMenu.rb:89
+msgctxt "MainMenu"
+msgid "Speed &test"
+msgstr "スピードテスト(&T)"
+
+#: ../src/eapi/MainMenu.rb:90
+msgctxt "MainMenu"
+msgid "Create &Portable version"
+msgstr "ポータブル版を作成(&P)"
+
+#: ../src/eapi/MainMenu.rb:91
+msgctxt "MainMenu"
+msgid "&Reinstall"
+msgstr "再インストール(&R)"
+
+#: ../src/eapi/MainMenu.rb:92
+msgctxt "MainMenu"
+msgid "&Install"
+msgstr "インストール(&I)"
+
+#: ../src/eapi/MainMenu.rb:94
+msgctxt "MainMenu"
+msgid "&Log viewer"
+msgstr "ログビューア(&L)"
+
+#: ../src/eapi/MainMenu.rb:95
+msgctxt "MainMenu"
+msgid "&Console"
+msgstr "コンソール(&C)"
+
+#: ../src/eapi/MainMenu.rb:96
+msgctxt "MainMenu"
+msgid "Relo&ad all programs"
+msgstr "すべてのプログラムを再読み込み(&A)"
+
+#: ../src/eapi/MainMenu.rb:99
+msgctxt "MainMenu"
+msgid "All programs reloaded"
+msgstr "すべてのプログラムが再読み込みされました"
+
+#: ../src/eapi/MainMenu.rb:101
+msgctxt "MainMenu"
+msgid "Load custom translation &file"
+msgstr "カスタム翻訳ファイルを読み込む(&F)"
+
+#: ../src/eapi/MainMenu.rb:102
+msgctxt "MainMenu"
+msgid "Select translations file"
+msgstr "翻訳ファイルを選択"
+
+#: ../src/eapi/MainMenu.rb:105
+msgctxt "MainMenu"
+msgid "Translation loaded"
+msgstr "翻訳が読み込まれました"
+
+#: ../src/eapi/MainMenu.rb:108
+msgctxt "MainMenu"
+msgid "De&bugging"
+msgstr "デバッグ(&B)"
+
+#: ../src/eapi/MainMenu.rb:110
+msgctxt "MainMenu"
+msgid "&Help"
+msgstr "ヘルプ(&H)"
+
+#: ../src/eapi/MainMenu.rb:111
+msgctxt "MainMenu"
+msgid "Frequently asked &questions"
+msgstr "よくある質問(&Q)"
+
+#: ../src/eapi/MainMenu.rb:112
+msgctxt "MainMenu"
+msgid "&Changelog"
+msgstr "変更履歴(&C)"
+
+#: ../src/eapi/MainMenu.rb:113
+msgctxt "MainMenu"
+msgid "Program &version"
+msgstr "プログラムバージョン(&V)"
+
+#: ../src/eapi/MainMenu.rb:114
+msgctxt "MainMenu"
+msgid "Sounds &guide"
+msgstr "サウンドガイド(&G)"
+
+#: ../src/eapi/MainMenu.rb:115
+msgctxt "MainMenu"
+msgid "&Read me"
+msgstr "&Read me"
+
+#: ../src/eapi/MainMenu.rb:116
+msgctxt "MainMenu"
+msgid "&License agreement"
+msgstr "ライセンス契約(&L)"
+
+#: ../src/eapi/MainMenu.rb:117
+msgctxt "MainMenu"
+msgid "&Terms and conditions"
+msgstr "利用規約(&T)"
+
+#: ../src/eapi/MainMenu.rb:118
+msgctxt "MainMenu"
+msgid "&Privacy policy"
+msgstr "プライバシーポリシー(&P)"
+
+#: ../src/eapi/MainMenu.rb:119
+msgctxt "MainMenu"
+msgid "Infor&mation about migration to Elten version 2.4"
+msgstr "エルテンバージョン２.４への移行に関する情報(&M)"
+
+#: ../src/eapi/MainMenu.rb:120
+msgctxt "MainMenu"
+msgid "List of &Invisible Interface hotkeys"
+msgstr "インビジブルインターフェースのホットキー一覧(&I)"
+
+#: ../src/eapi/MainMenu.rb:122
+msgctxt "MainMenu"
+msgid "&Quit"
+msgstr "終了(&Q)"
+
+#: ../src/eapi/MainMenu.rb:123
+msgctxt "MainMenu"
+msgid "Hide in &tray"
+msgstr "トレイに隠す(&T)"
+
+#: ../src/eapi/MainMenu.rb:127
+msgctxt "MainMenu"
+msgid "&Logout"
+msgstr "ログアウト(&L)"
+
+#: ../src/eapi/MainMenu.rb:138
+msgctxt "MainMenu"
+msgid "E&xit"
+msgstr "終了(&X)"
+
+#: ../src/eapi/MainMenu.rb:142
+msgctxt "MainMenu"
+msgid "&Restart"
+msgstr "再起動(&R)"
+
+#: ../src/eapi/MainMenu.rb:147
+msgctxt "MainMenu"
+msgid "Restart in de&bug mode"
+msgstr "デバッグモードで再起動(&B)"
+
+#: ../src/eapi/MainMenu.rb:155
+msgctxt "MainMenu"
+msgid "&Windows"
+msgstr "ウィンドウ(&W)"
+
+#: ../src/eapi/MainMenu.rb:162
+msgctxt "MainMenu"
+msgid "Window %{number}"
+msgstr "ウィンドウ %{number}"
+
+#: ../src/eapi/Network.rb:68
+msgctxt "EAPI_Network"
+msgid "sending..."
+msgstr "送信中..."
+
+#: ../src/eapi/Network.rb:184 ../src/eapi/Network.rb:229
+msgctxt "EAPI_Network"
+msgid "The file already exists. Do you want to override it?"
+msgstr "ファイルは既に存在します。上書きしますか？"
+
+#: ../src/eapi/Network.rb:291
+msgctxt "EAPI_Network"
+msgid "Do not report progress bar changes."
+msgstr "進行状況バーの変化を報告しない"
+
+#: ../src/eapi/Network.rb:294
+msgctxt "EAPI_Network"
+msgid "Read progress bar changes."
+msgstr "進行状況バーの変化を読み上げる"
+
+#: ../src/eapi/Program.rb:202
+msgctxt "Program"
+msgid "The program has been closed."
+msgstr "プログラムが終了しました。"
+
+#: ../src/eapi/QuickActions.rb:53
+msgctxt "EAPI_Common"
+msgid "Last spoken text copied to clipboard"
+msgstr "最後に読み上げたテキストをクリップボードにコピーしました"
+
+#: ../src/eapi/QuickActions.rb:58
+msgctxt "EAPI_Common"
+msgid "No tips available"
+msgstr "利用可能なヒントはありません"
+
+#: ../src/eapi/QuickActions.rb:93
+msgctxt "EAPI_Common"
+msgid "Using NVDA"
+msgstr "NVDAを使用しています"
+
+#: ../src/eapi/QuickActions.rb:95
+msgctxt "EAPI_Common"
+msgid "Using a selected SAPI synthesizer"
+msgstr "選択したSAPI音声合成を使用しています"
+
+#: ../src/eapi/QuickActions.rb:113
+msgctxt "EAPI_Common"
+msgid "Do not disturb on"
+msgstr "サイレントモードをオンにしました"
+
+#: ../src/eapi/QuickActions.rb:117
+msgctxt "EAPI_Common"
+msgid "Do not disturb off"
+msgstr "サイレントモードをオフにしました"
+
+#: ../src/eapi/QuickActions.rb:124
+msgctxt "EAPI_Common"
+msgid "Select audio file"
+msgstr "オーディオファイルを選択"
+
+#: ../src/eapi/QuickActions.rb:138
+msgctxt "EAPI_Common"
+msgid "Microphone muted"
+msgstr "マイクをミュートしました"
+
+#: ../src/eapi/QuickActions.rb:140
+msgctxt "EAPI_Common"
+msgid "Microphone unmuted"
+msgstr "マイクのミュートを解除しました"
+
+#: ../src/eapi/QuickActions.rb:187
+msgctxt "EAPI_QuickActions"
+msgid "What is new?"
+msgstr "新着情報"
+
+#: ../src/eapi/QuickActions.rb:188
+msgctxt "EAPI_QuickActions"
+msgid "My contacts"
+msgstr "私の連絡先"
+
+#: ../src/eapi/QuickActions.rb:189
+msgctxt "EAPI_QuickActions"
+msgid "Who is online?"
+msgstr "誰がオンライン？"
+
+#: ../src/eapi/QuickActions.rb:190
+msgctxt "EAPI_QuickActions"
+msgid "Messages"
+msgstr "メッセージ"
+
+#: ../src/eapi/QuickActions.rb:191
+msgctxt "EAPI_QuickActions"
+msgid "Forum"
+msgstr "フォーラム"
+
+#: ../src/eapi/QuickActions.rb:192
+msgctxt "EAPI_QuickActions"
+msgid "Blogs"
+msgstr "ブログ"
+
+#: ../src/eapi/QuickActions.rb:193
+msgctxt "EAPI_QuickActions"
+msgid "Conferences"
+msgstr "会議"
+
+#: ../src/eapi/QuickActions.rb:194
+msgctxt "EAPI_QuickActions"
+msgid "Premium packages"
+msgstr "プレミアムパッケージ"
+
+#: ../src/eapi/QuickActions.rb:206
+msgctxt "EAPI_QuickActions"
+msgid "Read tips on the current control"
+msgstr "現在のコントロールのヒントを読む"
+
+#: ../src/eapi/QuickActions.rb:207
+msgctxt "EAPI_QuickActions"
+msgid "Open context menu"
+msgstr "コンテキストメニューを開く"
+
+#: ../src/eapi/QuickActions.rb:208
+msgctxt "EAPI_QuickActions"
+msgid "Say time"
+msgstr "現在の時刻を読み上げる"
+
+#: ../src/eapi/QuickActions.rb:209
+msgctxt "EAPI_QuickActions"
+msgid "Say date"
+msgstr "現在の日付を読み上げる"
+
+#: ../src/eapi/QuickActions.rb:210
+msgctxt "EAPI_QuickActions"
+msgid "Speak last text"
+msgstr "最後のテキストを読み上げる"
+
+#: ../src/eapi/QuickActions.rb:211
+msgctxt "EAPI_QuickActions"
+msgid "Minimize Elten to tray"
+msgstr "Eltenをトレイに最小化"
+
+#: ../src/eapi/QuickActions.rb:212
+msgctxt "EAPI_QuickActions"
+msgid "Switch voice output between NVDA and Sapi5"
+msgstr "NVDAとSAPI5の音声出力を切り替える"
+
+#: ../src/eapi/QuickActions.rb:213
+msgctxt "EAPI_QuickActions"
+msgid "Volume down"
+msgstr "音量を下げる"
+
+#: ../src/eapi/QuickActions.rb:214
+msgctxt "EAPI_QuickActions"
+msgid "Volume up"
+msgstr "音量を上げる"
+
+#: ../src/eapi/QuickActions.rb:215
+msgctxt "EAPI_QuickActions"
+msgid "Switch \"Do not disturb\" mode"
+msgstr "サイレントモードを切り替える"
+
+#: ../src/eapi/QuickActions.rb:216
+msgctxt "EAPI_QuickActions"
+msgid "Publish to a feed"
+msgstr "フィードに公開する"
+
+#: ../src/eapi/QuickActions.rb:220
+msgctxt "EAPI_QuickActions"
+msgid "Copy last spoken text to clipboard"
+msgstr "最後に読み上げたテキストをクリップボードにコピーする"
+
+#: ../src/eapi/QuickActions.rb:221
+msgctxt "EAPI_QuickActions"
+msgid "Conferences: stream audio file"
+msgstr "会議：オーディオファイルをストリーム再生"
+
+#: ../src/eapi/QuickActions.rb:222
+msgctxt "EAPI_QuickActions"
+msgid "Conferences: set volumes"
+msgstr "会議：音量を設定"
+
+#: ../src/eapi/QuickActions.rb:223
+msgctxt "EAPI_QuickActions"
+msgid "Conferences: mute microphone"
+msgstr "会議：マイクをミュート"
+
+#: ../src/eapi/QuickActions.rb:224
+msgctxt "EAPI_QuickActions"
+msgid "Conferences: switch push to talk"
+msgstr "会議：プッシュ・トゥ・トークを切り替える"
+
+#: ../src/eapi/QuickActions.rb:225
+msgctxt "EAPI_QuickActions"
+msgid "Conferences: roll a 6-sided dice"
+msgstr "会議：6面ダイスを振る"
+
+#: ../src/eapi/QuickActions.rb:226
+msgctxt "EAPI_QuickActions"
+msgid "Conferences: roll a custom dice"
+msgstr "会議：カスタムダイスを振る"
+
+#: ../src/eapi/QuickActions.rb:227
+msgctxt "EAPI_QuickActions"
+msgid "Add alarm"
+msgstr "アラームを追加"
+
+#: ../src/eapi/Speech.rb:97 ../src/eapi/Speech.rb:436
+msgctxt "EAPI_Speech"
+msgid "Space"
+msgstr "スペース"
+
+#: ../src/eapi/Speech.rb:105
+msgctxt "EAPI_Speech"
+msgid "End of line"
+msgstr "行末"
+
+#: ../src/eapi/Speech.rb:148
+msgctxt "EAPI_Speech"
+msgid "New"
+msgstr "新規"
+
+#: ../src/eapi/Speech.rb:153
+msgctxt "EAPI_Speech"
+msgid "Closed"
+msgstr "閉鎖"
+
+#: ../src/eapi/Speech.rb:157
+msgctxt "EAPI_Speech"
+msgid "Restricted"
+msgstr "制限付き"
+
+#: ../src/eapi/Speech.rb:161
+msgctxt "EAPI_Speech"
+msgid "Future"
+msgstr "将来"
+
+#: ../src/eapi/Speech.rb:165
+msgctxt "EAPI_Speech"
+msgid "Online"
+msgstr "オンライン"
+
+#: ../src/eapi/Speech.rb:169
+msgctxt "EAPI_Speech"
+msgid "Sponsor"
+msgstr "スポンサー"
+
+#: ../src/eapi/Speech.rb:173
+msgctxt "EAPI_Speech"
+msgid "Pinned"
+msgstr "ピン留め"
+
+#: ../src/eapi/Speech.rb:177
+msgctxt "EAPI_Speech"
+msgid "Attachment"
+msgstr "添付ファイル"
+
+#: ../src/eapi/Speech.rb:181
+msgctxt "EAPI_Speech"
+msgid "Containing"
+msgstr "含む"
+
+#: ../src/eapi/Speech.rb:185
+msgctxt "EAPI_Speech"
+msgid "Liked"
+msgstr "いいね済み"
+
+#: ../src/eapi/Speech.rb:357
+msgctxt "EAPI_Speech"
+msgid "dot"
+msgstr "○"
+
+#: ../src/eapi/Speech.rb:359
+msgctxt "EAPI_Speech"
+msgid "comma"
+msgstr "点"
+
+#: ../src/eapi/Speech.rb:361
+msgctxt "EAPI_Speech"
+msgid "slash"
+msgstr "スラッシュ"
+
+#: ../src/eapi/Speech.rb:363
+msgctxt "EAPI_Speech"
+msgid "semi"
+msgstr "セミコロン"
+
+#: ../src/eapi/Speech.rb:365
+msgctxt "EAPI_Speech"
+msgid "tick"
+msgstr "アポストロフィー"
+
+#: ../src/eapi/Speech.rb:367
+msgctxt "EAPI_Speech"
+msgid "left bracket"
+msgstr "かぎ"
+
+#: ../src/eapi/Speech.rb:369
+msgctxt "EAPI_Speech"
+msgid "right bracket"
+msgstr "かぎ閉じ"
+
+#: ../src/eapi/Speech.rb:371
+msgctxt "EAPI_Speech"
+msgid "backslash"
+msgstr "えん"
+
+#: ../src/eapi/Speech.rb:373
+msgctxt "EAPI_Speech"
+msgid "dash"
+msgstr "ハイフン"
+
+#: ../src/eapi/Speech.rb:375
+msgctxt "EAPI_Speech"
+msgid "equals"
+msgstr "イコール"
+
+#: ../src/eapi/Speech.rb:377
+msgctxt "EAPI_Speech"
+msgid "graav"
+msgstr "アクサングラーブ"
+
+#: ../src/eapi/Speech.rb:379
+msgctxt "EAPI_Speech"
+msgid "less"
+msgstr "小なり"
+
+#: ../src/eapi/Speech.rb:381
+msgctxt "EAPI_Speech"
+msgid "greater"
+msgstr "大なり"
+
+#: ../src/eapi/Speech.rb:383
+msgctxt "EAPI_Speech"
+msgid "question"
+msgstr "疑問符"
+
+#: ../src/eapi/Speech.rb:385
+msgctxt "EAPI_Speech"
+msgid "colon"
+msgstr "コロン"
+
+#: ../src/eapi/Speech.rb:387
+msgctxt "EAPI_Speech"
+msgid "quote"
+msgstr "引用符"
+
+#: ../src/eapi/Speech.rb:389
+msgctxt "EAPI_Speech"
+msgid "left brace"
+msgstr "中かっこ"
+
+#: ../src/eapi/Speech.rb:391
+msgctxt "EAPI_Speech"
+msgid "right brace"
+msgstr "中かっこ閉じ"
+
+#: ../src/eapi/Speech.rb:393
+msgctxt "EAPI_Speech"
+msgid "bar"
+msgstr "縦棒"
+
+#: ../src/eapi/Speech.rb:395
+msgctxt "EAPI_Speech"
+msgid "line"
+msgstr "アンダーライン"
+
+#: ../src/eapi/Speech.rb:397
+msgctxt "EAPI_Speech"
+msgid "plus"
+msgstr "プラス"
+
+#: ../src/eapi/Speech.rb:399
+msgctxt "EAPI_Speech"
+msgid "bang"
+msgstr "感嘆符"
+
+#: ../src/eapi/Speech.rb:401
+msgctxt "EAPI_Speech"
+msgid "at"
+msgstr "アット"
+
+#: ../src/eapi/Speech.rb:403
+msgctxt "EAPI_Speech"
+msgid "hash"
+msgstr "シャープ"
+
+#: ../src/eapi/Speech.rb:405
+msgctxt "EAPI_Speech"
+msgid "dollar"
+msgstr "ドル"
+
+#: ../src/eapi/Speech.rb:407
+msgctxt "EAPI_Speech"
+msgid "percent"
+msgstr "パーセント"
+
+#: ../src/eapi/Speech.rb:409
+msgctxt "EAPI_Speech"
+msgid "caret"
+msgstr "べき乗"
+
+#: ../src/eapi/Speech.rb:411
+msgctxt "EAPI_Speech"
+msgid "and"
+msgstr "アンド"
+
+#: ../src/eapi/Speech.rb:413
+msgctxt "EAPI_Speech"
+msgid "star"
+msgstr "アスタリスク"
+
+#: ../src/eapi/Speech.rb:415
+msgctxt "EAPI_Speech"
+msgid "left paren"
+msgstr "かっこ"
+
+#: ../src/eapi/Speech.rb:417
+msgctxt "EAPI_Speech"
+msgid "right paren"
+msgstr "かっこ閉じ"
+
+#: ../src/eapi/UI.rb:295
+msgctxt "EAPI_UI"
+msgid "Do you want to restart Elten?"
+msgstr "エルテンを再起動しますか？"
+
+#: ../src/eapi/UI.rb:332
+msgctxt "EAPI_UI"
+msgid "%{user} is calling you"
+msgstr "%{user} があなたに電話をかけています"
+
+#: ../src/eapi/UI.rb:333
+msgctxt "EAPI_UI"
+msgid "Answer"
+msgstr "応答"
+
+#: ../src/eapi/UI.rb:334
+msgctxt "EAPI_UI"
+msgid "Reject"
+msgstr "拒否"
+
+#: ../src/eapi/UI.rb:354
+msgctxt "EAPI_UI"
+msgid "Unanswered calls"
+msgstr "不在着信"
+
+#: ../src/eapi/UI.rb:355
+msgctxt "EAPI_UI"
+msgid "Call back"
+msgstr "かけなおす"
+
+#: ../src/eapi/UI.rb:356
+msgctxt "EAPI_UI"
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/eapi/UI.rb:369
+msgctxt "EAPI_UI"
+msgid "You cannot call this user"
+msgstr "このユーザーをかけられません"
+
+#: ../src/eapi/UI.rb:509
+msgctxt "EAPI_UI"
+msgid "An unexpected error of Elten agent occurred. Do you want to report this event? It  may definitely help us solve the problem."
+msgstr "エルテンエージェントの予期しないエラーが発生しました。この問題を報告しますか？問題解決の手助けとなります。"
+
+#: ../src/eapi/UI.rb:513
+msgctxt "EAPI_UI"
+msgid "The program is trying to recover from the frozen state."
+msgstr "プログラムがフリーズ状態からの復旧を試みています。"
+
+#: ../src/eapi/UI.rb:588
+msgctxt "EAPI_UI"
+msgid "Errors occurred while trying to register keys for invisible interface. Please make sure that other apps do not use the keys specified. You can change modifier keys of invisible interface using settings window."
+msgstr "インビジブルインターフェースのキーを登録中にエラーが発生しました。 他のアプリが指定されたキーを使用していないことを確認してください。 設定ウィンドウでインビジブルインターフェースの修飾キーを変更できます。"
+
+#: ../src/eapi/UI.rb:672
+msgctxt "EAPI_UI"
+msgid "Alarm"
+msgstr "アラーム"
+
+#: ../src/eapi/UI.rb:751 ../src/scenes/Login.rb:146 ../src/scenes/Login.rb:148
+msgid "No"
+msgstr "いいえ"
+
+#: ../src/eapi/UI.rb:751 ../src/scenes/Login.rb:146 ../src/scenes/Login.rb:148
+msgid "Yes"
+msgstr "はい"
+
+#: ../src/eapi/__eapi.rb:853
+msgctxt "EAPI_EltenAPI"
+msgid "Do you want to send reports on how Elten is used? This data does not contain any confidential information and is very helpful in program development. This selection can be changed at any time from the Settings."
+msgstr "エルテンの使用状況レポートを送信しますか？このデータには機密情報は含まれず、プログラム開発に非常に役立ちます。この選択は、設定からいつでも変更できます。"
+
+#: ../src/eapi/__eapi.rb:858
+msgctxt "EAPI_EltenAPI"
+msgid ""
+"You are currently using a beta version of Elten. In these versions, uploading usage statistics is always enabled. They contain information about the most frequently used functions, configurations and problems with program operation. They do not contain any "
+"confidential or private information. If you do not want to send statistics, please use the stable version of Elten."
+msgstr ""
+"現在、エルテンのベータ版を使用しています。これらのバージョンでは、使用状況統計のアップロードが常に有効になっています。これらには、最も頻繁に使用される機能、設定、およびプログラムの動作に関する問題の情報が含まれます。機密情報や個人情報は含まれていません。統計を送信"
+"したくない場合は、エルテンの安定版をご利用ください。"
+
+#: ../src/scenes/Account.rb:114
+msgctxt "Account"
+msgid "Category"
+msgstr "カテゴリ"
+
+#: ../src/scenes/Account.rb:115 ../src/scenes/Blog.rb:1563 ../src/scenes/Forum.rb:4350 ../src/scenes/Settings.rb:117
+msgid "Apply"
+msgstr "適用"
+
+#: ../src/scenes/Account.rb:120
+msgctxt "Account"
+msgid "Profile"
+msgstr "プロフィール"
+
+#: ../src/scenes/Account.rb:121
+msgctxt "Account"
+msgid "Full name"
+msgstr "氏名"
+
+#: ../src/scenes/Account.rb:122
+msgid "Male"
+msgstr "男性"
+
+#: ../src/scenes/Account.rb:122
+msgctxt "Account"
+msgid "Gender"
+msgstr "性別"
+
+#: ../src/scenes/Account.rb:125
+msgid "March"
+msgstr "３月"
+
+#: ../src/scenes/Account.rb:125
+msgid "April"
+msgstr "４月"
+
+#: ../src/scenes/Account.rb:125
+msgid "May"
+msgstr "５月"
+
+#: ../src/scenes/Account.rb:125
+msgid "June"
+msgstr "６月"
+
+#: ../src/scenes/Account.rb:125
+msgid "January"
+msgstr "１月"
+
+#: ../src/scenes/Account.rb:125
+msgid "August"
+msgstr "８月"
+
+#: ../src/scenes/Account.rb:125
+msgid "February"
+msgstr "２月"
+
+#: ../src/scenes/Account.rb:125
+msgid "July"
+msgstr "７月"
+
+#: ../src/scenes/Account.rb:125
+msgid "December"
+msgstr "１２月"
+
+#: ../src/scenes/Account.rb:125
+msgid "September"
+msgstr "９月"
+
+#: ../src/scenes/Account.rb:125
+msgid "October"
+msgstr "１０月"
+
+#: ../src/scenes/Account.rb:125
+msgid "November"
+msgstr "１１月"
+
+#: ../src/scenes/Account.rb:127
+msgctxt "Account"
+msgid "Birth date: year"
+msgstr "生年月日：年"
+
+#: ../src/scenes/Account.rb:127
+msgctxt "Account"
+msgid "Don't specify"
+msgstr "指定しない"
+
+#: ../src/scenes/Account.rb:128
+msgctxt "Account"
+msgid "Birth date: month"
+msgstr "生年月日：月"
+
+#: ../src/scenes/Account.rb:129
+msgctxt "Account"
+msgid "Birth date: day"
+msgstr "生年月日：日"
+
+#: ../src/scenes/Account.rb:130
+msgctxt "Account"
+msgid "Country"
+msgstr "国"
+
+#: ../src/scenes/Account.rb:131
+msgctxt "Account"
+msgid "State / Province"
+msgstr "都道府県"
+
+#: ../src/scenes/Account.rb:132
+msgctxt "Account"
+msgid "City"
+msgstr "市町村"
+
+#: ../src/scenes/Account.rb:212 ../src/scenes/Account.rb:213
+msgctxt "Account"
+msgid "Visiting card"
+msgstr "名刺"
+
+#: ../src/scenes/Account.rb:216 ../src/scenes/Account.rb:224
+msgctxt "Account"
+msgid "Languages"
+msgstr "言語"
+
+#: ../src/scenes/Account.rb:225
+msgctxt "account"
+msgid "First language"
+msgstr "第一言語"
+
+#: ../src/scenes/Account.rb:247
+msgctxt "Account"
+msgid "Privacy"
+msgstr "プライバシー"
+
+#: ../src/scenes/Account.rb:248
+msgctxt "Account"
+msgid "Hide my profile for strangers"
+msgstr "見知らぬ人にプロフィールを非表示にする"
+
+#: ../src/scenes/Account.rb:249
+msgctxt "Account"
+msgid "Prevent banned users from writing me private messages"
+msgstr "禁止されたユーザーがプライベートメッセージを送信できないようにする"
+
+#: ../src/scenes/Account.rb:250
+msgctxt "Account"
+msgid "Accept incoming voice calls"
+msgstr "着信音声通話を受け入れる"
+
+#: ../src/scenes/Account.rb:250
+msgctxt "Account"
+msgid "Never"
+msgstr "受け入れない"
+
+#: ../src/scenes/Account.rb:250
+msgctxt "Account"
+msgid "Only from my friends"
+msgstr "友達からのみ"
+
+#: ../src/scenes/Account.rb:250
+msgctxt "Account"
+msgid "From all users"
+msgstr "すべてのユーザーから"
+
+#: ../src/scenes/Account.rb:251 ../src/scenes/Account.rb:509
+msgctxt "Account"
+msgid "Black list"
+msgstr "ブラックリスト"
+
+#: ../src/scenes/Account.rb:254
+msgctxt "Account"
+msgid "Status and signature"
+msgstr "ステータスと署名"
+
+#: ../src/scenes/Account.rb:255
+msgctxt "Account"
+msgid "Status displayed after your name on all lists of users"
+msgstr "ユーザー一覧であなたの名前の後に表示されるステータス"
+
+#: ../src/scenes/Account.rb:256
+msgctxt "Account"
+msgid "Signature placed below all your forum posts"
+msgstr "フォーラムの投稿全ての下に表示される署名"
+
+#: ../src/scenes/Account.rb:257
+msgctxt "Account"
+msgid "Greeting read after you log in to Elten"
+msgstr "Eltenにログインした後に読み上げられる挨拶文"
+
+#: ../src/scenes/Account.rb:260
+msgctxt "Account"
+msgid "What's new notifications"
+msgstr "新着通知"
+
+#: ../src/scenes/Account.rb:261
+msgctxt "Account"
+msgid "Notice only"
+msgstr "通知のみ"
+
+#: ../src/scenes/Account.rb:261
+msgctxt "Account"
+msgid "Notice and show in what's new"
+msgstr "通知して「新着情報」に表示"
+
+#: ../src/scenes/Account.rb:261
+msgctxt "Account"
+msgid "Ignore"
+msgstr "無視"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "Mentions"
+msgstr "メンション"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New messages"
+msgstr "新しいメッセージ"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New posts in followed threads"
+msgstr "フォロー中のスレッドの新しい投稿"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New posts on the followed blogs"
+msgstr "フォロー中のブログの新しい投稿"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New comments on your blog"
+msgstr "あなたのブログへの新しいコメント"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New threads on followed forums"
+msgstr "フォロー中のフォーラムの新しいスレッド"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New posts on followed forums"
+msgstr "フォロー中のフォーラムの新しい投稿"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "New friends"
+msgstr "新しい友達"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "Friends' birthday"
+msgstr "友達の誕生日"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "Awaiting group invitations"
+msgstr "保留中のグループ招待"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "Followed blog posts"
+msgstr "フォロー中のブログ投稿"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "Blog followers"
+msgstr "ブログのフォロワー"
+
+#: ../src/scenes/Account.rb:262
+msgctxt "Account"
+msgid "Blog mentions"
+msgstr "ブログのメンション"
+
+#: ../src/scenes/Account.rb:269
+msgctxt "Account"
+msgid "Account security"
+msgstr "アカウントのセキュリティ"
+
+#: ../src/scenes/Account.rb:270
+msgctxt "Account"
+msgid "Change e-mail"
+msgstr "メールアドレスを変更"
+
+#: ../src/scenes/Account.rb:271
+msgctxt "Account"
+msgid "Change password"
+msgstr "パスワードを変更"
+
+#: ../src/scenes/Account.rb:272
+msgctxt "Account"
+msgid "Forgot password"
+msgstr "パスワードを忘れた"
+
+#: ../src/scenes/Account.rb:273
+msgctxt "Account"
+msgid "Manage Two-Factor authentication"
+msgstr "二要素認証の管理"
+
+#: ../src/scenes/Account.rb:274
+msgctxt "Account"
+msgid "Manage mail events-reporting"
+msgstr "メールイベント通知の管理"
+
+#: ../src/scenes/Account.rb:275
+msgctxt "Account"
+msgid "Manage auto-login tokens"
+msgstr "自動ログイントークンの管理"
+
+#: ../src/scenes/Account.rb:276
+msgctxt "Account"
+msgid "Show last logins"
+msgstr "最後のログインを表示"
+
+#: ../src/scenes/Account.rb:279
+msgctxt "Account"
+msgid "Others"
+msgstr "その他"
+
+#: ../src/scenes/Account.rb:280
+msgctxt "Account"
+msgid "Premium packages"
+msgstr "プレミアムパッケージ"
+
+#: ../src/scenes/Account.rb:281
+msgctxt "Account"
+msgid "Archive this account"
+msgstr "このアカウントをアーカイブ"
+
+#: ../src/scenes/Account.rb:323
+msgctxt "Account"
+msgid "Enter your old password."
+msgstr "古いパスワードを入力してください。"
+
+#: ../src/scenes/Account.rb:330
+msgctxt "Account"
+msgid "Enter your new password."
+msgstr "新しいパスワードを入力してください。"
+
+#: ../src/scenes/Account.rb:338
+msgctxt "Account"
+msgid "Repeat new password."
+msgstr "新しいパスワードを再入力してください。"
+
+#: ../src/scenes/Account.rb:345
+msgctxt "Account"
+msgid "Fields: New Password and Repeat New Password have different values."
+msgstr "「新しいパスワード」と「新しいパスワードの再入力」のフィールドが異なります。"
+
+#: ../src/scenes/Account.rb:352
+msgctxt "Account"
+msgid "Your password has been changed."
+msgstr "パスワードが変更されました。"
+
+#: ../src/scenes/Account.rb:361 ../src/scenes/Account.rb:398
+msgctxt "Account"
+msgid "The old password is incorrect."
+msgstr "古いパスワードが正しくありません。"
+
+#: ../src/scenes/Account.rb:372 ../src/scenes/Account.rb:412 ../src/scenes/Account.rb:469 ../src/scenes/Account.rb:582 ../src/scenes/Account.rb:628 ../src/scenes/Account.rb:706
+msgctxt "Account"
+msgid "Enter your password."
+msgstr "パスワードを入力してください。"
+
+#: ../src/scenes/Account.rb:379
+msgctxt "Account"
+msgid "Enter a new e-mail address."
+msgstr "新しいメールアドレスを入力してください。"
+
+#: ../src/scenes/Account.rb:389
+msgctxt "Account"
+msgid "E-mail has been changed."
+msgstr "メールアドレスが変更されました。"
+
+#: ../src/scenes/Account.rb:401
+msgctxt "Account"
+msgid "Error, you must disable mail events reporting first."
+msgstr "エラー：まずメールイベント通知を無効にする必要があります。"
+
+#: ../src/scenes/Account.rb:419 ../src/scenes/Account.rb:477 ../src/scenes/Account.rb:589
+msgctxt "Account"
+msgid "An error occurred while authenticating the account. You might have provided an  incorrect password."
+msgstr "アカウントの認証中にエラーが発生しました。パスワードが間違っている可能性があります。"
+
+#: ../src/scenes/Account.rb:444
+msgctxt "Account"
+msgid "Creation IP Address"
+msgstr "作成時のIPアドレス"
+
+#: ../src/scenes/Account.rb:444
+msgctxt "Account"
+msgid "Generation date"
+msgstr "生成日"
+
+#: ../src/scenes/Account.rb:444
+msgctxt "Account"
+msgid "Computer"
+msgstr "コンピューター"
+
+#: ../src/scenes/Account.rb:449
+msgctxt "Account"
+msgid "Auto log in tokens"
+msgstr "自動ログイントークン"
+
+#: ../src/scenes/Account.rb:451
+msgctxt "Account"
+msgid "Log out all sessions"
+msgstr "すべてのセッションからログアウト"
+
+#: ../src/scenes/Account.rb:467
+msgctxt "Account"
+msgid "Are you sure you want to remove all auto log in tokens and log out all sessions?  You will be logged off immediately."
+msgstr "すべての自動ログイントークンを削除し、すべてのセッションからログアウトしてもよろしいですか？すぐにログアウトされます。"
+
+#: ../src/scenes/Account.rb:529
+msgctxt "Account"
+msgid "Add"
+msgstr "追加"
+
+#: ../src/scenes/Account.rb:530
+msgctxt "Account"
+msgid "User you want to add to the blacklist."
+msgstr "ブラックリストに追加したいユーザー。"
+
+#: ../src/scenes/Account.rb:532
+msgctxt "Account"
+msgid "The users added to your black list cannot send you private messages. Are you sure  you want to continue?"
+msgstr "ブラックリストに追加されたユーザーは、あなたにプライベートメッセージを送信できなくなります。続行してもよろしいですか？"
+
+#: ../src/scenes/Account.rb:536
+msgctxt "Account"
+msgid "User %{user} has been added to your blacklist"
+msgstr "ユーザー %{user} があなたのブラックリストに追加されました"
+
+#: ../src/scenes/Account.rb:546
+msgctxt "Account"
+msgid "You cannot add an administrator to the black list."
+msgstr "管理者をブラックリストに追加することはできません。"
+
+#: ../src/scenes/Account.rb:548
+msgctxt "Account"
+msgid "This user is already on your black list."
+msgstr "このユーザーは既にブラックリストに登録されています。"
+
+#: ../src/scenes/Account.rb:550
+msgctxt "Account"
+msgid "The user cannot be found."
+msgstr "ユーザーが見つかりません。"
+
+#: ../src/scenes/Account.rb:558
+msgctxt "Account"
+msgid "Are you sure you want to remove this user from the black list?"
+msgstr "このユーザーをブラックリストから削除してもよろしいですか？"
+
+#: ../src/scenes/Account.rb:563
+msgctxt "Account"
+msgid "A user has been removed from the black list."
+msgstr "ユーザーがブラックリストから削除されました。"
+
+#: ../src/scenes/Account.rb:616
+msgctxt "Account"
+msgid "Last logins"
+msgstr "最近のログイン"
+
+#: ../src/scenes/Account.rb:637
+msgctxt "Account"
+msgid "If you wish, you can configure Elten to report any changes and logins  on your account from new devices to you by E-mail. To do this, you must verify your E-mail address. Do you want to do it now?"
+msgstr "必要に応じて、新しいデバイスからのアカウントの変更やログインをメールで報告するようにEltenを設定できます。そのためには、メールアドレスを確認する必要があります。今すぐ行いますか？"
+
+#: ../src/scenes/Account.rb:643 ../src/scenes/Account.rb:668
+msgctxt "Account"
+msgid "The verification code has been sent to you via E-mail. Please type it here."
+msgstr "確認コードがメールで送信されました。ここに入力してください。"
+
+#: ../src/scenes/Account.rb:655
+msgctxt "Account"
+msgid "Enable mail events reporting"
+msgstr "メールイベント報告を有効にする"
+
+#: ../src/scenes/Account.rb:655
+msgctxt "Account"
+msgid "Disable mail events reporting"
+msgstr "メールイベント報告を無効にする"
+
+#: ../src/scenes/Account.rb:656
+msgctxt "Account"
+msgid "Mail events reporting is disabled. If you wish, you can enable it to receive information about changes made on your account and logins from new devices via E-mail"
+msgstr "メールイベント報告は無効になっています。ご希望の場合、メールを通じてアカウントの変更や新しいデバイスからのログイン情報を受け取るために有効にすることができます。"
+
+#: ../src/scenes/Account.rb:656
+msgctxt "Account"
+msgid "Mail events reporting is enabled."
+msgstr "メールイベント報告は有効になっています。"
+
+#: ../src/scenes/Account.rb:684
+msgctxt "Account"
+msgid ""
+"Archiving your account will have the following effects:\n"
+"* An indication that the account is archived will be placed next to all posts on the forum.\n"
+"* The account will not be displayed in the users lists.\n"
+"* The account will be removed from all contact lists.\n"
+"* Users will not be able to send private messages to this account.\n"
+"* The profile (including status, visiting card and signature) will be removed from the server\n"
+"* You will be opted out off all groups you are not moderating or banned in\n"
+"* You will be opted out of all messages conversations\n"
+"* All information about threads followed by you, your pinned groups or marked threads will be removed\n"
+"\n"
+"Attention.\n"
+"Archiving an account does not mean deleting or hiding associated blogs or notes, this must be done manually before archiving.\n"
+"\n"
+"The account will be automatically unarchived the next time you log in, but removed data will not be restored.."
+msgstr ""
+"アカウントをアーカイブすると、以下の効果があります：\n"
+"* フォーラムのすべての投稿の横に、アカウントがアーカイブされたことを示す表示がされます。\n"
+"* ユーザーリストにアカウントが表示されなくなります。\n"
+"* アカウントはすべての連絡先リストから削除されます。\n"
+"* ユーザーはこのアカウントにプライベートメッセージを送信できなくなります。\n"
+"* プロフィール（ステータス、名刺、署名を含む）がサーバーから削除されます。\n"
+"* あなたが管理者または禁止されていないすべてのグループから脱退します。\n"
+"* すべてのメッセージ会話から脱退します。\n"
+"* あなたがフォローしているスレッド、ピン留めしたグループ、マークしたスレッドに関するすべての情報が削除されます。\n"
+"\n"
+"注意。\n"
+"アカウントをアーカイブすることは、関連するブログやノートを削除または非表示にすることを意味しません。これはアーカイブ前に手動で行う必要があります。\n"
+"\n"
+"次回ログインすると、アカウントは自動的にアーカイブ解除されますが、削除されたデータは復元されません。"
+
+#: ../src/scenes/Account.rb:700
+msgctxt "Account"
+msgid "Information"
+msgstr "情報"
+
+#: ../src/scenes/Account.rb:701
+msgctxt "Account"
+msgid "Continue"
+msgstr "続行"
+
+#: ../src/scenes/Account.rb:710
+msgctxt "Account"
+msgid "Are you sure you want to archive this account?"
+msgstr "このアカウントをアーカイブしてもよろしいですか？"
+
+#: ../src/scenes/Account.rb:712
+msgctxt "Account"
+msgid "Account archived"
+msgstr "アカウントがアーカイブされました"
+
+#: ../src/scenes/Admins.rb:15
+msgctxt "Admins"
+msgid "Recommended groups Moderators"
+msgstr "推奨グループのモデレーター"
+
+#: ../src/scenes/Admins.rb:15
+msgctxt "Admins"
+msgid "Community Administrators"
+msgstr "コミュニティ管理者"
+
+#: ../src/scenes/Admins.rb:15
+msgctxt "Admins"
+msgid "Translators"
+msgstr "翻訳者"
+
+#: ../src/scenes/Admins.rb:15
+msgctxt "Admins"
+msgid "Developers"
+msgstr "開発者"
+
+#: ../src/scenes/Admins.rb:15
+msgctxt "Admins"
+msgid "Council of elders"
+msgstr "長老会"
+
+#: ../src/scenes/Admins.rb:15
+msgctxt "Admins"
+msgid "Sponsors"
+msgstr "スポンサー"
+
+#: ../src/scenes/Admins.rb:93
+msgctxt "Admins"
+msgid "Administrators and authors"
+msgstr "管理者と著者"
+
+#: ../src/scenes/Authentication.rb:23
+msgid "Enable"
+msgstr "有効にする"
+
+#: ../src/scenes/Authentication.rb:23
+msgctxt "Authentication"
+msgid ""
+"Two-factor authentication enables better account security by requiring the  confirmation of each login with your phone. When activated, a text message with a  verification code will be sent to you each time you log in from a new device.  Entering this code will be "
+"required to sign in to the program."
+msgstr ""
+"二要素認証を有効にすると、ログインごとに電話での確認が必要になり、アカウントのセキュリティが向上します。有効化すると、新しいデバイスからログインするたびに認証コードが記載されたテキストメッセージが送信されます。このコードを入力することで、プログラムへのサインインが"
+"可能になります。"
+
+#: ../src/scenes/Authentication.rb:25
+msgctxt "Authentication"
+msgid "Two-factor authentication is enabled on this account."
+msgstr "このアカウントでは二要素認証が有効になっています。"
+
+#: ../src/scenes/Authentication.rb:25
+msgid "Disable"
+msgstr "無効にする"
+
+#: ../src/scenes/Authentication.rb:25
+msgctxt "Authentication"
+msgid "Generate backup codes"
+msgstr "バックアップコードを生成"
+
+#: ../src/scenes/Authentication.rb:32 ../src/scenes/Authentication.rb:70 ../src/scenes/Authentication.rb:87
+msgctxt "Authentication"
+msgid "Type your password"
+msgstr "パスワードを入力してください"
+
+#: ../src/scenes/Authentication.rb:34
+msgctxt "Authentication"
+msgid "Type your phone number that will be used during verification. Remember to enter  the country code, for example, +48 for Poland"
+msgstr "認証に使用する電話番号を入力してください。国コードを忘れずに入力してください（例：ポーランドの場合は+48）"
+
+#: ../src/scenes/Authentication.rb:36
+msgctxt "Authentication"
+msgid "Two-factor authentication was introduced in Elten 2.28. After activating it, it  will not be possible to log in from the older versions of the program. DO you  wish to continue anyway?"
+msgstr "二要素認証はエルテン２.２８で導入されました。これを有効化すると、古いバージョンのプログラムからログインできなくなります。それでも続行しますか？"
+
+#: ../src/scenes/Authentication.rb:37
+msgctxt "Authentication"
+msgid "Is this phone number correct? Press enter to continue or escape to cancel."
+msgstr "この電話番号でよろしいですか？続行するにはEnterキーを、キャンセルするにはEscキーを押してください。"
+
+#: ../src/scenes/Authentication.rb:39
+msgctxt "Authentication"
+msgid "Please wait, connecting to the server ..."
+msgstr "お待ちください、サーバーに接続しています..."
+
+#: ../src/scenes/Authentication.rb:47
+msgctxt "Authentication"
+msgid "On the phone number indicated, you will receive a text message with the code  activating two-factor authentication. Enter this code"
+msgstr "指定した電話番号に、二要素認証を有効化するコードが記載されたテキストメッセージが届きます。このコードを入力してください"
+
+#: ../src/scenes/Authentication.rb:55
+msgctxt "Authentication"
+msgid "The entered code is not correct. Try again."
+msgstr "入力されたコードが正しくありません。再試行してください。"
+
+#: ../src/scenes/Authentication.rb:57
+msgctxt "Authentication"
+msgid "The entered code is not correct."
+msgstr "入力されたコードが正しくありません。"
+
+#: ../src/scenes/Authentication.rb:61
+msgctxt "Authentication"
+msgid "Two-factor authentication has been activated on this account."
+msgstr "このアカウントで二要素認証が有効になりました。"
+
+#: ../src/scenes/Authentication.rb:71
+msgctxt "Authentication"
+msgid "Are you sure you want to disable two-factor authentication?"
+msgstr "本当に二要素認証を無効にしますか？"
+
+#: ../src/scenes/Authentication.rb:74
+msgctxt "Authentication"
+msgid "Two-factor authentication has been disabled."
+msgstr "二要素認証が無効になりました。"
+
+#: ../src/scenes/Authentication.rb:76
+msgctxt "Authentication"
+msgid "Invalid password"
+msgstr "無効なパスワードです"
+
+#: ../src/scenes/Authentication.rb:85
+msgctxt "Authentication"
+msgid "Do you want to generate backup codes? These can be used to sign in when you have no access to your phone. All previously generated codes will be deleted."
+msgstr "バックアップコードを生成しますか？これらは電話にアクセスできない場合にサインインするために使用できます。以前に生成されたコードはすべて削除されます。"
+
+#: ../src/scenes/Authentication.rb:97
+msgctxt "Authentication"
+msgid "Generated backup codes"
+msgstr "生成されたバックアップコード"
+
+#: ../src/scenes/Ban.rb:16
+msgctxt "Ban"
+msgid "Enter a username to ban"
+msgstr "禁止するユーザー名を入力してください"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "5 years"
+msgstr "５年間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "Three days"
+msgstr "３日間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "A week"
+msgstr "１週間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "2 weeks"
+msgstr "２週間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "30 days"
+msgstr "３０日間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "90 days"
+msgstr "９０日間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "180 days"
+msgstr "１８０日間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "A year"
+msgstr "１年間"
+
+#: ../src/scenes/Ban.rb:25
+msgctxt "Ban"
+msgid "A day"
+msgstr "１日間"
+
+#: ../src/scenes/Ban.rb:26
+msgctxt "Ban"
+msgid "Ban time"
+msgstr "禁止期間"
+
+#: ../src/scenes/Ban.rb:26
+msgctxt "Ban"
+msgid "The reason"
+msgstr "理由"
+
+#: ../src/scenes/Ban.rb:26
+msgctxt "Ban"
+msgid "Ban"
+msgstr "禁止"
+
+#: ../src/scenes/Ban.rb:26
+msgctxt "Ban"
+msgid "Ban IP address"
+msgstr "IPアドレスを禁止"
+
+#: ../src/scenes/Ban.rb:26
+msgctxt "Ban"
+msgid "An additional message to the user"
+msgstr "ユーザーへの追加メッセージ"
+
+#: ../src/scenes/Ban.rb:70
+msgctxt "Ban"
+msgid "Banned."
+msgstr "禁止されました。"
+
+#: ../src/scenes/Ban.rb:93
+msgctxt "Ban"
+msgid "Enter a username to unban."
+msgstr "禁止を解除するユーザー名を入力してください。"
+
+#: ../src/scenes/Ban.rb:113
+msgctxt "Ban"
+msgid "The ban reason"
+msgstr "禁止の理由"
+
+#: ../src/scenes/Ban.rb:113
+msgctxt "Ban"
+msgid "Ban valid until"
+msgstr "禁止の有効期限"
+
+#: ../src/scenes/Ban.rb:113
+msgctxt "Ban"
+msgid "The ban cancel reason"
+msgstr "禁止解除の理由"
+
+#: ../src/scenes/Ban.rb:113
+msgctxt "Ban"
+msgid "Unban"
+msgstr "禁止を解除"
+
+#: ../src/scenes/Ban.rb:123
+msgctxt "Ban"
+msgid "Unbanned."
+msgstr "禁止が解除されました。"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Frequently updated blogs"
+msgstr "頻繁に更新されるブログ"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Managed blogs"
+msgstr "管理しているブログ"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Blogs popular with my friends"
+msgstr "友達に人気のブログ"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Frequently commented blogs"
+msgstr "頻繁にコメントされるブログ"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Followed blogs"
+msgstr "フォロー中のブログ"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Open external wordpress blog"
+msgstr "外部のWordPressブログを開く"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Followed blog posts"
+msgstr "フォロー中のブログ投稿"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Received mentions"
+msgstr "受信したメンション"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Blogs library"
+msgstr "ブログライブラリ"
+
+#: ../src/scenes/Blog.rb:13 ../src/scenes/Blog.rb:700
+msgctxt "Blog"
+msgid "Blogs"
+msgstr "ブログ"
+
+#: ../src/scenes/Blog.rb:13
+msgctxt "Blog"
+msgid "Recently updated blogs"
+msgstr "最近更新されたブログ"
+
+#: ../src/scenes/Blog.rb:56
+msgctxt "Blog"
+msgid "Type blog address"
+msgstr "ブログのアドレスを入力してください"
+
+#: ../src/scenes/Blog.rb:103
+msgctxt "Blog"
+msgid "The blog cannot be found."
+msgstr "ブログが見つかりません。"
+
+#: ../src/scenes/Blog.rb:137
+msgctxt "Blog"
+msgid "All posts"
+msgstr "すべての投稿"
+
+#: ../src/scenes/Blog.rb:138 ../src/scenes/Blog.rb:863 ../src/scenes/Blog.rb:1651
+msgctxt "Blog"
+msgid "Posts"
+msgstr "投稿"
+
+#: ../src/scenes/Blog.rb:163 ../src/scenes/Blog.rb:184
+msgctxt "Blog"
+msgid "Category name"
+msgstr "カテゴリ名"
+
+#: ../src/scenes/Blog.rb:170
+msgctxt "Blog"
+msgid "The category has been created."
+msgstr "カテゴリが作成されました。"
+
+#: ../src/scenes/Blog.rb:191
+msgctxt "Blog"
+msgid "The category has been renamed."
+msgstr "カテゴリ名が変更されました。"
+
+#: ../src/scenes/Blog.rb:201
+msgctxt "Blog"
+msgid "Are you sure you want to delete this category?"
+msgstr "このカテゴリを削除してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:206
+msgctxt "Blog"
+msgid "Category deleted"
+msgstr "カテゴリが削除されました"
+
+#: ../src/scenes/Blog.rb:215 ../src/scenes/Blog.rb:466
+msgctxt "Blog"
+msgid "Select"
+msgstr "選択"
+
+#: ../src/scenes/Blog.rb:219
+msgctxt "Blog"
+msgid "Rename"
+msgstr "名前を変更"
+
+#: ../src/scenes/Blog.rb:227
+msgctxt "Blog"
+msgid "Copy category URL"
+msgstr "カテゴリのURLをコピー"
+
+#: ../src/scenes/Blog.rb:229
+msgctxt "Blog"
+msgid "Category URL copied to clipboard"
+msgstr "カテゴリのURLがクリップボードにコピーされました"
+
+#: ../src/scenes/Blog.rb:233
+msgctxt "Blog"
+msgid "New category"
+msgstr "新しいカテゴリ"
+
+#: ../src/scenes/Blog.rb:248
+msgctxt "Blog"
+msgid "You do not have any blog. Do you want to create one?"
+msgstr "あなたはブログを持っていません。作成しますか？"
+
+#: ../src/scenes/Blog.rb:253
+msgctxt "Blog"
+msgid "Type a blog name"
+msgstr "ブログ名を入力してください"
+
+#: ../src/scenes/Blog.rb:258 ../src/scenes/Blog.rb:2166
+msgctxt "Blog"
+msgid "Please wait..."
+msgstr "お待ちください..."
+
+#: ../src/scenes/Blog.rb:270
+msgctxt "Blog"
+msgid "The blog has been created."
+msgstr "ブログが作成されました。"
+
+#: ../src/scenes/Blog.rb:311 ../src/scenes/Blog.rb:863
+msgctxt "Blog"
+msgid "Author"
+msgstr "著者"
+
+#: ../src/scenes/Blog.rb:311 ../src/scenes/Blog.rb:863 ../src/scenes/Blog.rb:1583 ../src/scenes/Blog.rb:2233
+msgctxt "Blog"
+msgid "Comments"
+msgstr "コメント"
+
+#: ../src/scenes/Blog.rb:321
+msgctxt "Blog"
+msgid "No new comments on your blog."
+msgstr "あなたのブログに新しいコメントはありません。"
+
+#: ../src/scenes/Blog.rb:325
+msgctxt "Blog"
+msgid "No new comments to followed blog posts."
+msgstr "フォロー中のブログ投稿に新しいコメントはありません。"
+
+#: ../src/scenes/Blog.rb:329
+msgctxt "Blog"
+msgid "No new posts on followed blogs."
+msgstr "フォロー中のブログに新しい投稿はありません。"
+
+#: ../src/scenes/Blog.rb:333
+msgctxt "Blog"
+msgid "No new blog mentions."
+msgstr "新しいブログのメンションはありません。"
+
+#: ../src/scenes/Blog.rb:427
+msgctxt "Blog"
+msgid "Mentioned by"
+msgstr "メンションしたユーザー"
+
+#: ../src/scenes/Blog.rb:430 ../src/scenes/Blog.rb:1370
+msgctxt "Blog"
+msgid "New"
+msgstr "新規"
+
+#: ../src/scenes/Blog.rb:437
+msgctxt "Blog"
+msgid "Load more"
+msgstr "さらに読み込む"
+
+#: ../src/scenes/Blog.rb:451
+msgctxt "Blog"
+msgid "Are you sure you want to delete this post?"
+msgstr "この投稿を削除してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:456
+msgctxt "Blog"
+msgid "Post deleted"
+msgstr "投稿が削除されました"
+
+#: ../src/scenes/Blog.rb:471
+msgctxt "Blog"
+msgid "Edit"
+msgstr "編集"
+
+#: ../src/scenes/Blog.rb:474
+msgctxt "Blog"
+msgid "Move to another blog"
+msgstr "別のブログに移動"
+
+#: ../src/scenes/Blog.rb:483
+msgctxt "Blog"
+msgid "Sort posts by date"
+msgstr "投稿を日付順に並べ替える"
+
+#: ../src/scenes/Blog.rb:485
+msgctxt "Blog"
+msgid "Sort posts by blog"
+msgstr "投稿をブログ別に並べ替える"
+
+#: ../src/scenes/Blog.rb:490
+msgctxt "Blog"
+msgid "Posts sorted by date."
+msgstr "投稿が日付順に並べ替えられました。"
+
+#: ../src/scenes/Blog.rb:493
+msgctxt "Blog"
+msgid "Posts sorted by blog."
+msgstr "投稿がブログ別に並べ替えられました。"
+
+#: ../src/scenes/Blog.rb:499 ../src/scenes/Blog.rb:513
+msgctxt "Blog"
+msgid "Mention post"
+msgstr "投稿をメンションする"
+
+#: ../src/scenes/Blog.rb:510
+msgctxt "Blog"
+msgid "Nobody added you to their contact list."
+msgstr "誰もあなたを連絡先リストに追加していません。"
+
+#: ../src/scenes/Blog.rb:513
+msgctxt "Blog"
+msgid "User to mention"
+msgstr "メンションするユーザー"
+
+#: ../src/scenes/Blog.rb:513
+msgctxt "Blog"
+msgid "Message"
+msgstr "メッセージ"
+
+#: ../src/scenes/Blog.rb:527
+msgctxt "Blog"
+msgid "The mention has been sent."
+msgstr "メンションが送信されました。"
+
+#: ../src/scenes/Blog.rb:536 ../src/scenes/Blog.rb:793
+msgctxt "Blog"
+msgid "Follow this post"
+msgstr "この投稿をフォローする"
+
+#: ../src/scenes/Blog.rb:538 ../src/scenes/Blog.rb:795
+msgctxt "Blog"
+msgid "Unfollow this post"
+msgstr "この投稿のフォローを解除する"
+
+#: ../src/scenes/Blog.rb:551 ../src/scenes/Blog.rb:808
+msgctxt "Blog"
+msgid "Post followed"
+msgstr "投稿をフォローしました"
+
+#: ../src/scenes/Blog.rb:554 ../src/scenes/Blog.rb:811
+msgctxt "Blog"
+msgid "Post unfollowed"
+msgstr "投稿のフォローを解除しました"
+
+#: ../src/scenes/Blog.rb:561
+msgctxt "Blog"
+msgid "Copy post URL"
+msgstr "投稿のURLをコピー"
+
+#: ../src/scenes/Blog.rb:563
+msgctxt "Blog"
+msgid "Post URL copied to clipboard"
+msgstr "投稿のURLがクリップボードにコピーされました"
+
+#: ../src/scenes/Blog.rb:567
+msgctxt "Blog"
+msgid "New post"
+msgstr "新しい投稿"
+
+#: ../src/scenes/Blog.rb:663
+msgctxt "Blog"
+msgid "Show attached media"
+msgstr "添付メディアを表示"
+
+#: ../src/scenes/Blog.rb:667
+msgctxt "Blog"
+msgid "Media"
+msgstr "メディア"
+
+#: ../src/scenes/Blog.rb:684
+msgctxt "Blog"
+msgid "Your comment"
+msgstr "あなたのコメント"
+
+#: ../src/scenes/Blog.rb:690
+msgctxt "Blog"
+msgid "Edit your post"
+msgstr "自分の投稿を編集"
+
+#: ../src/scenes/Blog.rb:694
+msgctxt "Blog"
+msgid "Return"
+msgstr "戻る"
+
+#: ../src/scenes/Blog.rb:706 ../src/scenes/Blog.rb:1960
+msgctxt "Blog"
+msgid "Send"
+msgstr "送信"
+
+#: ../src/scenes/Blog.rb:731
+msgctxt "Blog"
+msgid "The comment has been added."
+msgstr "コメントが追加されました。"
+
+#: ../src/scenes/Blog.rb:779
+msgctxt "Blog"
+msgid "Received mention"
+msgstr "メンションを受信しました"
+
+#: ../src/scenes/Blog.rb:780
+msgctxt "Blog"
+msgid "Show mention"
+msgstr "メンションを表示"
+
+#: ../src/scenes/Blog.rb:781
+msgctxt "Blog"
+msgid "Mention by %{user}"
+msgstr "%{user} からのメンション"
+
+#: ../src/scenes/Blog.rb:783
+msgctxt "Blog"
+msgid "Send reply to mentioner"
+msgstr "メンションしたユーザーに返信を送る"
+
+#: ../src/scenes/Blog.rb:819
+msgctxt "Blog"
+msgid "Navigation"
+msgstr "ナビゲーション"
+
+#: ../src/scenes/Blog.rb:820
+msgctxt "Blog"
+msgid "Go to post"
+msgstr "投稿に移動"
+
+#: ../src/scenes/Blog.rb:824
+msgctxt "Blog"
+msgid "Go to last comment"
+msgstr "最後のコメントに移動"
+
+#: ../src/scenes/Blog.rb:829
+msgctxt "Blog"
+msgid "Go to first unread comment"
+msgstr "未読の最初のコメントに移動"
+
+#: ../src/scenes/Blog.rb:836
+msgctxt "Blog"
+msgid "Write a comment"
+msgstr "コメントを書く"
+
+#: ../src/scenes/Blog.rb:842
+msgctxt "Blog"
+msgid "Delete this comment"
+msgstr "このコメントを削除"
+
+#: ../src/scenes/Blog.rb:843 ../src/scenes/Blog.rb:2259
+msgctxt "Blog"
+msgid "Are you sure you want to delete this comment?"
+msgstr "このコメントを削除してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:863
+msgctxt "Blog"
+msgid "Last post"
+msgstr "最新の投稿"
+
+#: ../src/scenes/Blog.rb:863
+msgctxt "Blog"
+msgid "Blogs list"
+msgstr "ブログリスト"
+
+#: ../src/scenes/Blog.rb:899 ../src/scenes/Blog.rb:1098
+msgctxt "Blog"
+msgid "Coworkers"
+msgstr "共同作成者"
+
+#: ../src/scenes/Blog.rb:903
+msgctxt "Blog"
+msgid "Add coworker"
+msgstr "共同作成者を追加"
+
+#: ../src/scenes/Blog.rb:904
+msgctxt "Blog"
+msgid "What user you want to add to this blog?"
+msgstr "このブログに追加したいユーザーは誰ですか？"
+
+#: ../src/scenes/Blog.rb:914
+msgctxt "Blog"
+msgid "Delete coworker"
+msgstr "共同作成者を削除"
+
+#: ../src/scenes/Blog.rb:915
+msgctxt "Blog"
+msgid "Are you sure you want to release this coworker?"
+msgstr "この共同作成者を解除してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:935
+msgctxt "Blog"
+msgid "Are you sure you want to delete blog %{name}?"
+msgstr "ブログ %{name} を削除してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:936
+msgctxt "Blog"
+msgid "All posts written on this blog will be lost. Are you sure you want to continue?"
+msgstr "このブログに書かれたすべての投稿が失われます。続行してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:938
+msgctxt "Blog"
+msgid "Blog deleted"
+msgstr "ブログが削除されました"
+
+#: ../src/scenes/Blog.rb:1003
+msgctxt "Blog"
+msgid "No blogs found"
+msgstr "ブログが見つかりません"
+
+#: ../src/scenes/Blog.rb:1046 ../src/scenes/Blog.rb:1570
+msgctxt "Blog"
+msgid "Blog description"
+msgstr "ブログの説明"
+
+#: ../src/scenes/Blog.rb:1047
+msgctxt "Blog"
+msgid "Blog language"
+msgstr "ブログの言語"
+
+#: ../src/scenes/Blog.rb:1048
+msgctxt "Blog"
+msgid "Add"
+msgstr "追加"
+
+#: ../src/scenes/Blog.rb:1058
+msgctxt "Blog"
+msgid "Blog added to library"
+msgstr "ブログがライブラリに追加されました"
+
+#: ../src/scenes/Blog.rb:1075
+msgctxt "Blog"
+msgid "Open"
+msgstr "開く"
+
+#: ../src/scenes/Blog.rb:1079
+msgctxt "Blog"
+msgid "Show all posts"
+msgstr "すべての投稿を表示"
+
+#: ../src/scenes/Blog.rb:1083
+msgctxt "Blog"
+msgid "Search"
+msgstr "検索"
+
+#: ../src/scenes/Blog.rb:1084
+msgctxt "Blog"
+msgid "Enter text to search"
+msgstr "検索するテキストを入力"
+
+#: ../src/scenes/Blog.rb:1092
+msgctxt "Blog"
+msgid "Blog options"
+msgstr "ブログのオプション"
+
+#: ../src/scenes/Blog.rb:1095 ../src/scenes/Blog.rb:2367
+msgctxt "Blog"
+msgid "Followers"
+msgstr "フォロワー"
+
+#: ../src/scenes/Blog.rb:1102
+msgctxt "Blog"
+msgid "Leave"
+msgstr "退出"
+
+#: ../src/scenes/Blog.rb:1103
+msgctxt "Blog"
+msgid "Are you sure you want to stop co-creating this blog?"
+msgstr "このブログの共同作成をやめてもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:1105
+msgctxt "Blog"
+msgid "Blog left"
+msgstr "ブログを退出しました"
+
+#: ../src/scenes/Blog.rb:1113
+msgctxt "Blog"
+msgid "Recategorize"
+msgstr "カテゴリを変更"
+
+#: ../src/scenes/Blog.rb:1118
+msgctxt "Blog"
+msgid "Delete this blog"
+msgstr "このブログを削除"
+
+#: ../src/scenes/Blog.rb:1126
+msgctxt "Blog"
+msgid "Remove from the followed blogs"
+msgstr "フォロー中のブログから削除"
+
+#: ../src/scenes/Blog.rb:1128
+msgctxt "Blog"
+msgid "Add to followed blogs"
+msgstr "フォロー中のブログに追加"
+
+#: ../src/scenes/Blog.rb:1137
+msgctxt "Blog"
+msgid "This blog has been added to followed blogs. Do you want to mark all the posts published so far on it as read so that you don't see them in \"What's New\"?"
+msgstr "このブログはフォロー中のブログに追加されました。これまでに公開されたすべての投稿を既読にして、「新着情報」に表示されないようにしますか？"
+
+#: ../src/scenes/Blog.rb:1140 ../src/scenes/Blog.rb:1185
+msgctxt "Blog"
+msgid "The blog has been marked as read."
+msgstr "ブログが既読としてマークされました。"
+
+#: ../src/scenes/Blog.rb:1152
+msgctxt "Blog"
+msgid "Removed from the followed blogs."
+msgstr "フォロー中のブログから削除されました。"
+
+#: ../src/scenes/Blog.rb:1159
+msgctxt "Blog"
+msgid "Add to Elten library"
+msgstr "Eltenライブラリに追加"
+
+#: ../src/scenes/Blog.rb:1164
+msgctxt "Blog"
+msgid "Delete from Elten library"
+msgstr "Eltenライブラリから削除"
+
+#: ../src/scenes/Blog.rb:1165
+msgctxt "Blog"
+msgid "Are you sure you want to delete this blog from Elten library?"
+msgstr "このブログをEltenライブラリから削除してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:1172
+msgctxt "Blog"
+msgid "Add this blog to quick actions"
+msgstr "このブログをクイックアクションに追加"
+
+#: ../src/scenes/Blog.rb:1173 ../src/scenes/Blog.rb:2369
+msgctxt "Blog"
+msgid "Blog"
+msgstr "ブログ"
+
+#: ../src/scenes/Blog.rb:1174
+msgctxt "Blog"
+msgid "Blog added to quick actions"
+msgstr "ブログがクイックアクションに追加されました"
+
+#: ../src/scenes/Blog.rb:1176
+msgctxt "Blog"
+msgid "Copy blog URL"
+msgstr "ブログのURLをコピー"
+
+#: ../src/scenes/Blog.rb:1178
+msgctxt "Blog"
+msgid "Blog URL copied to clipboard"
+msgstr "ブログのURLがクリップボードにコピーされました"
+
+#: ../src/scenes/Blog.rb:1181
+msgctxt "Blog"
+msgid "Mark the blog as read"
+msgstr "ブログを既読としてマーク"
+
+#: ../src/scenes/Blog.rb:1182
+msgctxt "Blog"
+msgid "All posts on this blog will be marked as read. Do you want to continue?"
+msgstr "このブログのすべての投稿が既読としてマークされます。続行しますか？"
+
+#: ../src/scenes/Blog.rb:1193
+msgctxt "Blog"
+msgid "Create new blog"
+msgstr "新しいブログを作成"
+
+#: ../src/scenes/Blog.rb:1207
+msgctxt "Blog"
+msgid "You cannot create more blogs"
+msgstr "これ以上ブログを作成できません"
+
+#: ../src/scenes/Blog.rb:1212
+msgctxt "Blog"
+msgid "Show blogs in unknown languages"
+msgstr "未知の言語のブログを表示"
+
+#: ../src/scenes/Blog.rb:1213
+msgctxt "Blog"
+msgid "Hide blogs in unknown languages"
+msgstr "未知の言語のブログを非表示"
+
+#: ../src/scenes/Blog.rb:1243
+msgctxt "Blog"
+msgid "Wordpress user login"
+msgstr "WordPressユーザーログイン"
+
+#: ../src/scenes/Blog.rb:1244
+msgctxt "Blog"
+msgid "Set new Wordpress password"
+msgstr "新しいWordPressパスワードを設定"
+
+#: ../src/scenes/Blog.rb:1245
+msgctxt "Blog"
+msgid "First name"
+msgstr "名"
+
+#: ../src/scenes/Blog.rb:1246
+msgctxt "Blog"
+msgid "Last name"
+msgstr "姓"
+
+#: ../src/scenes/Blog.rb:1247
+msgctxt "Blog"
+msgid "Nick"
+msgstr "ニックネーム"
+
+#: ../src/scenes/Blog.rb:1248
+msgctxt "Blog"
+msgid "Display name"
+msgstr "表示名"
+
+#: ../src/scenes/Blog.rb:1249
+msgctxt "Blog"
+msgid "User description"
+msgstr "ユーザーの説明"
+
+#: ../src/scenes/Blog.rb:1276
+msgctxt "Blog"
+msgid "Your Elten Password"
+msgstr "あなたのエルテンパスワード"
+
+#: ../src/scenes/Blog.rb:1283
+msgctxt "Blog"
+msgid "New Wordpress password"
+msgstr "新しいWordPressパスワード"
+
+#: ../src/scenes/Blog.rb:1286
+msgctxt "Blog"
+msgid "Repeat new Wordpress password"
+msgstr "新しいWordPressパスワードを再入力"
+
+#: ../src/scenes/Blog.rb:1290
+msgctxt "Blog"
+msgid "Wordpress password must be at least 6 characters long."
+msgstr "WordPressパスワードは6文字以上である必要があります。"
+
+#: ../src/scenes/Blog.rb:1295
+msgctxt "Blog"
+msgid "Entered passwords are different."
+msgstr "入力されたパスワードが異なります。"
+
+#: ../src/scenes/Blog.rb:1409
+msgctxt "Blog"
+msgid "Recategorized"
+msgstr "カテゴリが変更されました"
+
+#: ../src/scenes/Blog.rb:1443
+msgctxt "Blog"
+msgid "Copy this post and all comments"
+msgstr "この投稿とすべてのコメントをコピー"
+
+#: ../src/scenes/Blog.rb:1443
+msgctxt "Blog"
+msgid "Post destination"
+msgstr "投稿の移動先"
+
+#: ../src/scenes/Blog.rb:1443
+msgctxt "Blog"
+msgid "Move this post and all comments"
+msgstr "この投稿とすべてのコメントを移動する"
+
+#: ../src/scenes/Blog.rb:1443
+msgctxt "Blog"
+msgid "Move only this post, delete all comments"
+msgstr "この投稿のみを移動し、すべてのコメントを削除する"
+
+#: ../src/scenes/Blog.rb:1443
+msgctxt "Blog"
+msgid "Move type"
+msgstr "移動の種類"
+
+#: ../src/scenes/Blog.rb:1443
+msgctxt "Blog"
+msgid "Move"
+msgstr "移動"
+
+#: ../src/scenes/Blog.rb:1452
+msgctxt "Blog"
+msgid "The post has been moved."
+msgstr "投稿が移動されました。"
+
+#: ../src/scenes/Blog.rb:1562
+msgctxt "Blog"
+msgid "Category"
+msgstr "カテゴリ"
+
+#: ../src/scenes/Blog.rb:1568
+msgctxt "Blog"
+msgid "General"
+msgstr "一般"
+
+#: ../src/scenes/Blog.rb:1569
+msgctxt "Blog"
+msgid "Blog name"
+msgstr "ブログ名"
+
+#: ../src/scenes/Blog.rb:1579
+msgctxt "Blog"
+msgid "Language"
+msgstr "言語"
+
+#: ../src/scenes/Blog.rb:1580
+msgctxt "Blog"
+msgid "Mark this blog as public. Blogs that are not marked public request search engines such as Google not to show them in search results (some search engines may not respect this setting)"
+msgstr "このブログを公開としてマークします。公開としてマークされていないブログは、Googleなどの検索エンジンに検索結果に表示しないよう要求します（ただし、一部の検索エンジンはこの設定を無視する場合があります）"
+
+#: ../src/scenes/Blog.rb:1584
+msgctxt "Blog"
+msgid "Comments can be written"
+msgstr "コメントを書けるユーザー"
+
+#: ../src/scenes/Blog.rb:1584
+msgctxt "Blog"
+msgid "By all visitors"
+msgstr "すべての訪問者"
+
+#: ../src/scenes/Blog.rb:1584
+msgctxt "Blog"
+msgid "By all visitors, but I must commit first comment of the specific person"
+msgstr "すべての訪問者（ただし、特定の人物の最初のコメントは承認が必要）"
+
+#: ../src/scenes/Blog.rb:1584
+msgctxt "Blog"
+msgid "By all visitors, but I must commit all of them"
+msgstr "すべての訪問者（すべてのコメントを承認する必要がある）"
+
+#: ../src/scenes/Blog.rb:1584
+msgctxt "Blog"
+msgid "By Elten users only"
+msgstr "Eltenユーザーのみ"
+
+#: ../src/scenes/Blog.rb:1585
+msgctxt "Blog"
+msgid "Disable commenting of older posts"
+msgstr "古い投稿へのコメントを無効にする"
+
+#: ../src/scenes/Blog.rb:1586
+msgctxt "Blog"
+msgid "Days after commenting of a post will be disabled"
+msgstr "投稿後、コメントを無効にする日数"
+
+#: ../src/scenes/Blog.rb:1587
+msgctxt "Blog"
+msgid "Allow comments threading"
+msgstr "コメントのスレッド化を許可する"
+
+#: ../src/scenes/Blog.rb:1588
+msgctxt "Blog"
+msgid "Max comments thread depth"
+msgstr "コメントの最大スレッド深度"
+
+#: ../src/scenes/Blog.rb:1589
+msgctxt "Blog"
+msgid "Ascending"
+msgstr "昇順"
+
+#: ../src/scenes/Blog.rb:1589
+msgctxt "Blog"
+msgid "Descending"
+msgstr "降順"
+
+#: ../src/scenes/Blog.rb:1589
+msgctxt "Blog"
+msgid "Order comments on the website"
+msgstr "ウェブサイト上のコメントの順序"
+
+#: ../src/scenes/Blog.rb:1590
+msgctxt "Blog"
+msgid "Split comments on the website into pages"
+msgstr "ウェブサイト上のコメントをページ分割する"
+
+#: ../src/scenes/Blog.rb:1591
+msgctxt "Blog"
+msgid "Comments per page"
+msgstr "1ページあたりのコメント数"
+
+#: ../src/scenes/Blog.rb:1592
+msgctxt "Blog"
+msgid "Newest comments"
+msgstr "新しいコメント"
+
+#: ../src/scenes/Blog.rb:1592
+msgctxt "Blog"
+msgid "Oldest comments"
+msgstr "古いコメント"
+
+#: ../src/scenes/Blog.rb:1592
+msgctxt "Blog"
+msgid "Firstly display"
+msgstr "最初に表示する"
+
+#: ../src/scenes/Blog.rb:1593 ../src/scenes/Blog.rb:2266
+msgctxt "Blog"
+msgid "Pending comments"
+msgstr "保留中のコメント"
+
+#: ../src/scenes/Blog.rb:1652
+msgctxt "Blog"
+msgid "Posts displayed per page on the website"
+msgstr "ウェブサイト上で1ページに表示する投稿数"
+
+#: ../src/scenes/Blog.rb:1653
+msgctxt "Blog"
+msgid "Use emoticons"
+msgstr "絵文字を使用する"
+
+#: ../src/scenes/Blog.rb:1654
+msgctxt "Blog"
+msgid "Full date and post name (https://example.com/2020/01/01/example-post)"
+msgstr "完全な日付と投稿名（https://example.com/2020/01/01/example-post）"
+
+#: ../src/scenes/Blog.rb:1654
+msgctxt "Blog"
+msgid "Month and post name (https://example.com/2020/01/example-post)"
+msgstr "月と投稿名（https://example.com/2020/01/example-post）"
+
+#: ../src/scenes/Blog.rb:1654
+msgctxt "Blog"
+msgid "Just a post id (https://example.com/posts/123/)"
+msgstr "投稿IDのみ（https://example.com/posts/123/）"
+
+#: ../src/scenes/Blog.rb:1654
+msgctxt "Blog"
+msgid "Just a post name (https://example.com/example-post/)"
+msgstr "投稿名のみ（https://example.com/example-post/）"
+
+#: ../src/scenes/Blog.rb:1654
+msgctxt "Blog"
+msgid "Simple (https://example.com/?p=123)"
+msgstr "シンプル（https://example.com/?p=123）"
+
+#: ../src/scenes/Blog.rb:1658 ../src/scenes/Blog.rb:1682
+msgctxt "Blog"
+msgid "Custom"
+msgstr "カスタム"
+
+#: ../src/scenes/Blog.rb:1660
+msgctxt "Blog"
+msgid "Links format"
+msgstr "リンクの形式"
+
+#: ../src/scenes/Blog.rb:1661
+msgctxt "Blog"
+msgid "Posts in RSS"
+msgstr "RSSでの投稿数"
+
+#: ../src/scenes/Blog.rb:1662
+msgctxt "Blog"
+msgid "Use excerpts in RSS"
+msgstr "RSSで抜粋を使用する"
+
+#: ../src/scenes/Blog.rb:1665
+msgctxt "blog"
+msgid "Date and time"
+msgstr "日時"
+
+#: ../src/scenes/Blog.rb:1667
+msgctxt "Blog"
+msgid "31 January 2020"
+msgstr "２０２０年１月３１日"
+
+#: ../src/scenes/Blog.rb:1667
+msgctxt "Blog"
+msgid "January 31, 2020"
+msgstr "２０２０年１月３１日"
+
+#: ../src/scenes/Blog.rb:1668
+msgctxt "Blog"
+msgid "Date format"
+msgstr "日付の形式"
+
+#: ../src/scenes/Blog.rb:1671
+msgctxt "Blog"
+msgid "Time format"
+msgstr "時間の形式"
+
+#: ../src/scenes/Blog.rb:1685
+msgctxt "Blog"
+msgid "Timezone city"
+msgstr "タイムゾーンの都市"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Saturday"
+msgstr "土曜日"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Thursday"
+msgstr "木曜日"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Wednesday"
+msgstr "水曜日"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Tuesday"
+msgstr "火曜日"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Monday"
+msgstr "月曜日"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Sunday"
+msgstr "日曜日"
+
+#: ../src/scenes/Blog.rb:1686
+msgctxt "Blog"
+msgid "Friday"
+msgstr "金曜日"
+
+#: ../src/scenes/Blog.rb:1687
+msgctxt "Blog"
+msgid "First day of the week"
+msgstr "週の始まりの曜日"
+
+#: ../src/scenes/Blog.rb:1690
+msgctxt "Blog"
+msgid "Others"
+msgstr "その他"
+
+#: ../src/scenes/Blog.rb:1693
+msgctxt "Blog"
+msgid "Do not set"
+msgstr "設定しない"
+
+#: ../src/scenes/Blog.rb:1706
+msgctxt "Blog"
+msgid "If you want to redirect all browsers visiting this blog to another site, select it here"
+msgstr "このブログを訪問するすべてのブラウザを別のサイトにリダイレクトしたい場合は、ここで選択してください"
+
+#: ../src/scenes/Blog.rb:1708
+msgctxt "Blog"
+msgid "My Wordpress account"
+msgstr "自分のWordpressアカウント"
+
+#: ../src/scenes/Blog.rb:1709
+msgctxt "Blog"
+msgid "Open Wordpress admin panel in my browser"
+msgstr "ブラウザでWordpressの管理パネルを開く"
+
+#: ../src/scenes/Blog.rb:1719
+msgctxt "Blog"
+msgid "Manage tags"
+msgstr "タグを管理"
+
+#: ../src/scenes/Blog.rb:1720
+msgctxt "Blog"
+msgid "Manage blog domain"
+msgstr "ブログのドメインを管理"
+
+#: ../src/scenes/Blog.rb:1723
+msgctxt "Blog"
+msgid "Blog settings have been changed. If you continue to domain change, mades you changed will be lost. Do you want to continue anyway? If you want to store new settings, select No and then Apply them before proceeding with domain change."
+msgstr "ブログの設定が変更されました。ドメインの変更を続行すると、行った変更は失われます。それでも続行しますか？新しい設定を保存したい場合は、「いいえ」を選択し、ドメインの変更を行う前に適用してください。"
+
+#: ../src/scenes/Blog.rb:1861
+msgctxt "Blog"
+msgid "Tags"
+msgstr "タグ"
+
+#: ../src/scenes/Blog.rb:1863
+msgctxt "Blog"
+msgid "New tag"
+msgstr "新しいタグ"
+
+#: ../src/scenes/Blog.rb:1864
+msgctxt "Blog"
+msgid "Tag name"
+msgstr "タグ名"
+
+#: ../src/scenes/Blog.rb:1878
+msgctxt "Blog"
+msgid "Delete tag"
+msgstr "タグを削除"
+
+#: ../src/scenes/Blog.rb:1881
+msgid "error"
+msgstr "エラー"
+
+#: ../src/scenes/Blog.rb:1949
+msgctxt "Blog"
+msgid "Post title"
+msgstr "投稿のタイトル"
+
+#: ../src/scenes/Blog.rb:1950
+msgctxt "Blog"
+msgid "Source Editor (HTML and Wordpress Shortcodes)"
+msgstr "ソースエディタ（HTMLとWordpressショートコード）"
+
+#: ../src/scenes/Blog.rb:1950
+msgctxt "Blog"
+msgid "Formattable editor"
+msgstr "書式付きエディタ"
+
+#: ../src/scenes/Blog.rb:1950
+msgctxt "Blog"
+msgid "Editor"
+msgstr "エディタ"
+
+#: ../src/scenes/Blog.rb:1951 ../src/scenes/Blog.rb:2233
+msgctxt "Blog"
+msgid "Post"
+msgstr "投稿"
+
+#: ../src/scenes/Blog.rb:1952
+msgctxt "Blog"
+msgid "Audio content"
+msgstr "音声コンテンツ"
+
+#: ../src/scenes/Blog.rb:1953
+msgctxt "Blog"
+msgid "Post categories"
+msgstr "投稿のカテゴリ"
+
+#: ../src/scenes/Blog.rb:1954
+msgctxt "Blog"
+msgid "Post tags"
+msgstr "投稿のタグ"
+
+#: ../src/scenes/Blog.rb:1955
+msgctxt "Blog"
+msgid "Show to everyone"
+msgstr "すべての人に表示"
+
+#: ../src/scenes/Blog.rb:1955
+msgctxt "Blog"
+msgid "Visibility"
+msgstr "公開範囲"
+
+#: ../src/scenes/Blog.rb:1955
+msgctxt "Blog"
+msgid "Show to Elten users only"
+msgstr "Eltenユーザーのみに表示"
+
+#: ../src/scenes/Blog.rb:1956
+msgctxt "Blog"
+msgid "Excerpt"
+msgstr "抜粋"
+
+#: ../src/scenes/Blog.rb:1957
+msgctxt "Blog"
+msgid "Schedule this post to be published in the future"
+msgstr "この投稿を将来公開するようスケジュールする"
+
+#: ../src/scenes/Blog.rb:1958
+msgctxt "Blog"
+msgid "Publication date"
+msgstr "公開日"
+
+#: ../src/scenes/Blog.rb:1959
+msgctxt "Blog"
+msgid "Allow users to comment this post"
+msgstr "ユーザーがこの投稿にコメントすることを許可する"
+
+#: ../src/scenes/Blog.rb:1965
+msgctxt "Blog"
+msgid "Add existing tag to this post"
+msgstr "既存のタグをこの投稿に追加する"
+
+#: ../src/scenes/Blog.rb:1981
+msgctxt "Blog"
+msgid "Add tag to this post"
+msgstr "この投稿にタグを追加する"
+
+#: ../src/scenes/Blog.rb:1982
+msgctxt "Blog"
+msgid "Tag to add"
+msgstr "追加するタグ"
+
+#: ../src/scenes/Blog.rb:1991
+msgctxt "Blog"
+msgid "This tag does not exist, do you want to create it now?"
+msgstr "このタグは存在しません。今すぐ作成しますか？"
+
+#: ../src/scenes/Blog.rb:2003
+msgctxt "Blog"
+msgid "Remove tag from this post"
+msgstr "この投稿からタグを削除する"
+
+#: ../src/scenes/Blog.rb:2113
+msgctxt "Blog"
+msgid "Are you sure you want to cancel creating this post?"
+msgstr "この投稿の作成をキャンセルしてもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:2122
+msgctxt "Blog"
+msgid "Publication date not set"
+msgstr "公開日が設定されていません"
+
+#: ../src/scenes/Blog.rb:2126
+msgctxt "Blog"
+msgid "Selected publication date that is in the past"
+msgstr "過去の日付が公開日に選択されています"
+
+#: ../src/scenes/Blog.rb:2178
+msgctxt "Blog"
+msgid "The post has been added."
+msgstr "投稿が追加されました。"
+
+#: ../src/scenes/Blog.rb:2189
+msgctxt "Blog"
+msgid "There are currently no tags created, please add a new one."
+msgstr "現在、作成されたタグはありません。新しいタグを追加してください。"
+
+#: ../src/scenes/Blog.rb:2192
+msgctxt "Blog"
+msgid "Select tag"
+msgstr "タグを選択"
+
+#: ../src/scenes/Blog.rb:2233
+msgctxt "Blog"
+msgid "Comment"
+msgstr "コメント"
+
+#: ../src/scenes/Blog.rb:2250
+msgctxt "Blog"
+msgid "Approve"
+msgstr "承認"
+
+#: ../src/scenes/Blog.rb:2254
+msgctxt "Blog"
+msgid "Assign as spam"
+msgstr "スパムとして指定"
+
+#: ../src/scenes/Blog.rb:2258
+msgctxt "Blog"
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/scenes/Blog.rb:2264
+msgctxt "Blog"
+msgid "Show"
+msgstr "表示"
+
+#: ../src/scenes/Blog.rb:2273
+msgctxt "Blog"
+msgid "Comments assigned as spam"
+msgstr "スパムとして指定されたコメント"
+
+#: ../src/scenes/Blog.rb:2361
+msgctxt "Blog"
+msgid "This blog is not followed by any user"
+msgstr "このブログは誰にもフォローされていません"
+
+#: ../src/scenes/Blog.rb:2373
+msgctxt "Blog"
+msgid "Open blog"
+msgstr "ブログを開く"
+
+#: ../src/scenes/Blog.rb:2410
+msgctxt "Blog"
+msgid "Current blog domain"
+msgstr "現在のブログドメイン"
+
+#: ../src/scenes/Blog.rb:2411
+msgctxt "Blog"
+msgid "Change"
+msgstr "変更"
+
+#: ../src/scenes/Blog.rb:2430
+msgctxt "Blog"
+msgid "Personal Elten blog domain (%{username}.elten.blog)"
+msgstr "個人用Eltenブログドメイン（%{username}.elten.blog）"
+
+#: ../src/scenes/Blog.rb:2431
+msgctxt "Blog"
+msgid "Shared Elten blog domain (selectedname.s.elten.blog)"
+msgstr "共有Eltenブログドメイン（selectedname.s.elten.blog）"
+
+#: ../src/scenes/Blog.rb:2432
+msgctxt "Blog"
+msgid "External domain"
+msgstr "外部ドメイン"
+
+#: ../src/scenes/Blog.rb:2433
+msgctxt "Blog"
+msgid "Domain type"
+msgstr "ドメインの種類"
+
+#: ../src/scenes/Blog.rb:2435
+msgctxt "Blog"
+msgid "Buying your own domain"
+msgstr "独自ドメインの購入"
+
+#: ../src/scenes/Blog.rb:2435
+msgctxt "Blog"
+msgid ""
+"To continue, you should point your domain to Elten Blogging server.\n"
+"You can buy your own domain from domain providers, such as ovh.com, domain.com, godaddy.com or bluehost.com."
+msgstr ""
+"続行するには、あなたのドメインをEltenブログサーバーに向ける必要があります。\n"
+"独自のドメインは、ovh.com、domain.com、godaddy.com、bluehost.comなどのドメインプロバイダから購入できます。"
+
+#: ../src/scenes/Blog.rb:2437
+msgctxt "Blog"
+msgid "Final new blog address"
+msgstr "最終的な新しいブログアドレス"
+
+#: ../src/scenes/Blog.rb:2438
+msgctxt "Blog"
+msgid "Proceed with domain change"
+msgstr "ドメイン変更を進める"
+
+#: ../src/scenes/Blog.rb:2457
+msgctxt "Blog"
+msgid "Domain prefix (prefix.s.elten.blog)"
+msgstr "ドメインプレフィックス（prefix.s.elten.blog）"
+
+#: ../src/scenes/Blog.rb:2461
+msgctxt "Blog"
+msgid "Domain (like example.com)"
+msgstr "ドメイン（例：example.com）"
+
+#: ../src/scenes/Blog.rb:2473
+msgctxt "Blog"
+msgid "The new domain is the same as a previous one"
+msgstr "新しいドメインが以前のものと同じです"
+
+#: ../src/scenes/Blog.rb:2477
+msgctxt "Blog"
+msgid "You already have one blog associated with your Elten profile. Please change its type and then proceed."
+msgstr "あなたのEltenプロファイルにはすでに1つのブログが関連付けられています。そのタイプを変更してから続行してください。"
+
+#: ../src/scenes/Blog.rb:2481
+msgctxt "Blog"
+msgid "Only first level subdomains are allowed"
+msgstr "第一レベルのサブドメインのみ許可されています"
+
+#: ../src/scenes/Blog.rb:2485
+msgctxt "Blog"
+msgid "Blog subdomain must be at least 3 characters long"
+msgstr "ブログのサブドメインは少なくとも3文字以上である必要があります"
+
+#: ../src/scenes/Blog.rb:2490
+msgctxt "Blog"
+msgid "The entered domain contains invalid characters"
+msgstr "入力されたドメインには無効な文字が含まれています"
+
+#: ../src/scenes/Blog.rb:2494
+msgctxt "Blog"
+msgid "The entered domain is not valid"
+msgstr "入力されたドメインは有効ではありません"
+
+#: ../src/scenes/Blog.rb:2500
+msgctxt "Blog"
+msgid ""
+"Warning! If you change your blog URL, some links may stop working. If you directly linked posts or other resources on your blog, they would no longer be available at previous URLs. In such case you will be required to fix them manually. Are you sure you want to "
+"continue?"
+msgstr "警告！ブログのURLを変更すると、一部のリンクが機能しなくなる可能性があります。ブログ内の投稿や他のリソースに直接リンクしている場合、以前のURLでは利用できなくなります。その場合、それらを手動で修正する必要があります。続行してもよろしいですか？"
+
+#: ../src/scenes/Blog.rb:2514
+msgctxt "Blog"
+msgid "Blog domain changed"
+msgstr "ブログのドメインが変更されました"
+
+#: ../src/scenes/Blog.rb:2523
+msgctxt "Blog"
+msgid ""
+"You should now configure your purchased domain to redirect to Elten blogging server. Below are the necessary details. If you have any problems, please feel free to ask questions in the forum.\n"
+"      \n"
+"      Wherever possible, we recommend that you use the CNAME record, as it does not need to be edited if the IP address of the server hosting your blog changes. Your blog's IP address may change, for example, due to a Elten Blogging Server migration. By "
+"configuring your domain's CNAME record, you don't need to do anything else.\n"
+"      To do this, please point your cname record to destination \"%{host}.\"\n"
+"      \n"
+"      Unfortunately, many domain registrars do not support the CNAME record for top-level domains, so you may want to use the A record instead.\n"
+"      In such a case, please point the A record to IP address:\n"
+"%{ip}\n"
+".\n"
+"\n"
+"Please note that redirecting your domain is not aliasing and setting aliases or HTTP 301/ 3xx redirections will not work.\n"
+"\n"
+"You can get detailed description from your domain provider, for example at:\n"
+"https://support.us.ovhcloud.com/hc/en-us/articles/115001994890-Getting-Familiar-with-DNS\n"
+"\n"
+"Once completed, please continue."
+msgstr ""
+"購入したドメインをEltenブログサーバーにリダイレクトするように設定する必要があります。以下に必要な詳細を示します。問題がある場合は、フォーラムでお気軽にご質問ください。\n"
+"      \n"
+"      可能であれば、CNAMEレコードを使用することをお勧めします。これは、ブログをホストするサーバーのIPアドレスが変更された場合でも編集する必要がないためです。例えば、Eltenブログサーバーの移行によりブログのIPアドレスが変更される可能性があります。ドメインのCNAMEレコー"
+"ドを設定することで、それ以上の作業は必要ありません。\n"
+"      これを行うには、CNAMEレコードを宛先「%{host}」に向けてください。\n"
+"      \n"
+"      残念ながら、多くのドメインレジストラはトップレベルドメインのCNAMEレコードをサポートしていないため、代わりにAレコードを使用することをお勧めします。\n"
+"      その場合、AレコードをIPアドレスに向けてください：\n"
+"%{ip}\n"
+"。\n"
+"\n"
+"ドメインのリダイレクトはエイリアシングではなく、エイリアスの設定やHTTP 301/3xxリダイレクトは機能しないことに注意してください。\n"
+"\n"
+"詳細な説明は、ドメインプロバイダから入手できます。例えば、以下のサイトをご覧ください：\n"
+"https://support.us.ovhcloud.com/hc/en-us/articles/115001994890-Getting-Familiar-with-DNS\n"
+"\n"
+"完了したら、続行してください。"
+
+#: ../src/scenes/Blog.rb:2540
+msgctxt "Blog"
+msgid "Setting the domain"
+msgstr "ドメインの設定"
+
+#: ../src/scenes/Blog.rb:2541
+msgctxt "Blog"
+msgid "Ready, take me next"
+msgstr "準備完了、次へ進む"
+
+#: ../src/scenes/Blog.rb:2553
+msgctxt "Blog"
+msgid "Your domain is not pointing to Elten Blogs, please try again or wait a while to refresh DNS. It may take up to 24 hours to perform full DNS update."
+msgstr "あなたのドメインがEltenブログを指していません。再試行するか、DNSが更新されるまでしばらくお待ちください。完全なDNS更新には最大24時間かかる場合があります。"
+
+#: ../src/scenes/Blog.rb:2555
+msgctxt "Blog"
+msgid "Your domain is pointing to Elten blogs, but www prefix is not. Please fix it."
+msgstr "あなたのドメインはEltenブログを指していますが、wwwプレフィックスはそうではありません。修正してください。"
+
+#: ../src/scenes/Changes.rb:144
+msgctxt "Changes"
+msgid "Changelog"
+msgstr "変更履歴"
+
+#: ../src/scenes/Clock.rb:10
+msgctxt "Clock"
+msgid "Alarms"
+msgstr "アラーム"
+
+#: ../src/scenes/Clock.rb:17 ../src/scenes/Clock.rb:70 ../src/scenes/Clock.rb:97
+msgctxt "Clock"
+msgid "Hour"
+msgstr "時"
+
+#: ../src/scenes/Clock.rb:17 ../src/scenes/Clock.rb:70 ../src/scenes/Clock.rb:97
+msgctxt "Clock"
+msgid "Type"
+msgstr "タイプ"
+
+#: ../src/scenes/Clock.rb:17 ../src/scenes/Clock.rb:70 ../src/scenes/Clock.rb:97
+msgctxt "Clock"
+msgid "One time"
+msgstr "一度だけ"
+
+#: ../src/scenes/Clock.rb:17
+msgctxt "Clock"
+msgid "repeated"
+msgstr "繰り返し"
+
+#: ../src/scenes/Clock.rb:43
+msgctxt "Clock"
+msgid "Edit alarm"
+msgstr "アラームを編集"
+
+#: ../src/scenes/Clock.rb:46
+msgctxt "Clock"
+msgid "Delete alarm"
+msgstr "アラームを削除"
+
+#: ../src/scenes/Clock.rb:50
+msgctxt "Clock"
+msgid "New alarm"
+msgstr "新しいアラーム"
+
+#: ../src/scenes/Clock.rb:70 ../src/scenes/Clock.rb:97
+msgctxt "Clock"
+msgid "Repeated"
+msgstr "繰り返し"
+
+#: ../src/scenes/Clock.rb:70
+msgctxt "Clock"
+msgid "Alarm description"
+msgstr "アラームの説明"
+
+#: ../src/scenes/Clock.rb:70
+msgctxt "Clock"
+msgid "Minute"
+msgstr "分"
+
+#: ../src/scenes/Contacts.rb:44
+msgctxt "Contacts"
+msgid "Empty list"
+msgstr "リストが空です"
+
+#: ../src/scenes/Contacts.rb:50
+msgctxt "Contacts"
+msgid "Contacts"
+msgstr "連絡先"
+
+#: ../src/scenes/Contacts.rb:75
+msgctxt "Contacts"
+msgid "Are you sure you want to delete this contact?"
+msgstr "この連絡先を削除してもよろしいですか？"
+
+#: ../src/scenes/Contacts.rb:93
+msgctxt "Contacts"
+msgid "New contact"
+msgstr "新しい連絡先"
+
+#: ../src/scenes/Contacts.rb:108
+msgctxt "Contacts"
+msgid "Enter the name of the user you want to add to your contacts' list."
+msgstr "連絡先リストに追加したいユーザーの名前を入力してください。"
+
+#: ../src/scenes/Contacts.rb:124
+msgctxt "Contacts"
+msgid "Contact was added."
+msgstr "連絡先が追加されました。"
+
+#: ../src/scenes/Contacts.rb:133
+msgctxt "Contacts"
+msgid "This user is already added to your contacts' list."
+msgstr "このユーザーはすでに連絡先リストに追加されています。"
+
+#: ../src/scenes/Contacts.rb:136 ../src/scenes/Contacts.rb:169
+msgctxt "Contacts"
+msgid "This user does not exist."
+msgstr "このユーザーは存在しません。"
+
+#: ../src/scenes/Contacts.rb:151
+msgctxt "Contacts"
+msgid "Type a username which you want to remove from your contact list."
+msgstr "連絡先リストから削除したいユーザー名を入力してください。"
+
+#: ../src/scenes/Contacts.rb:157
+msgctxt "Contacts"
+msgid "Contact has been deleted."
+msgstr "連絡先が削除されました。"
+
+#: ../src/scenes/Contacts.rb:166
+msgctxt "Contacts"
+msgid "This user is not added to your contacts' list."
+msgstr "このユーザーは連絡先リストに追加されていません。"
+
+#: ../src/scenes/Debug.rb:9
+msgctxt "Debug"
+msgid "Report connections to the server"
+msgstr "サーバーへの接続を報告"
+
+#: ../src/scenes/Debug.rb:9
+msgctxt "Debug"
+msgid "OK"
+msgstr "OK"
+
+#: ../src/scenes/Debug.rb:9
+msgctxt "Debug"
+msgid "A report"
+msgstr "レポート"
+
+#: ../src/scenes/ForgotPassword.rb:11
+msgctxt "ForgotPassword"
+msgid ""
+"If you lose your password, you can still reset it via the E-mail address provided  during the registration process. This way you shall generate the password reset  code which will be used to verify your identity. The code will be sent to your e- mail address. "
+"Warning! Two-factor authentication will be disabled on your  account. To continue, enter your username"
+msgstr ""
+"パスワードを忘れた場合でも、登録時に提供したメールアドレスを使用してリセットできます。この方法で、本人確認に使用されるパスワードリセットコードを生成します。コードはあなたのメールアドレスに送信されます。警告！二要素認証はあなたのアカウントで無効になります。続行する"
+"には、ユーザー名を入力してください"
+
+#: ../src/scenes/ForgotPassword.rb:18
+msgctxt "ForgotPassword"
+msgid "Enter the E-mail address used during the registration process"
+msgstr "登録時に使用したメールアドレスを入力してください"
+
+#: ../src/scenes/ForgotPassword.rb:28
+msgctxt "ForgotPassword"
+msgid "The typed E-mail address is not associated with the entered username."
+msgstr "入力されたメールアドレスは、入力されたユーザー名と関連付けられていません。"
+
+#: ../src/scenes/ForgotPassword.rb:31
+msgctxt "ForgotPassword"
+msgid "Generate password reset code"
+msgstr "パスワードリセットコードを生成"
+
+#: ../src/scenes/ForgotPassword.rb:31
+msgctxt "ForgotPassword"
+msgid "Enter password reset code"
+msgstr "パスワードリセットコードを入力"
+
+#: ../src/scenes/ForgotPassword.rb:31
+msgctxt "ForgotPassword"
+msgid "Password reset"
+msgstr "パスワードリセット"
+
+#: ../src/scenes/ForgotPassword.rb:51
+msgctxt "ForgotPassword"
+msgid "Please wait while the password reset key is being generated."
+msgstr "パスワードリセットキーを生成しています。お待ちください。"
+
+#: ../src/scenes/ForgotPassword.rb:55 ../src/scenes/ForgotPassword.rb:91
+msgctxt "ForgotPassword"
+msgid "An unexpected error"
+msgstr "予期しないエラーが発生しました"
+
+#: ../src/scenes/ForgotPassword.rb:57
+msgctxt "ForgotPassword"
+msgid "Password reset key has been sent to your specified E-mail address. To continue,  select the option for entering key."
+msgstr "パスワードリセットキーが指定されたメールアドレスに送信されました。続行するには、キーを入力するオプションを選択してください。"
+
+#: ../src/scenes/ForgotPassword.rb:64
+msgctxt "ForgotPassword"
+msgid "Enter the generated password reset code"
+msgstr "生成されたパスワードリセットコードを入力してください"
+
+#: ../src/scenes/ForgotPassword.rb:70
+msgctxt "ForgotPassword"
+msgid "The entered code is invalid."
+msgstr "入力されたコードが無効です。"
+
+#: ../src/scenes/ForgotPassword.rb:75
+msgctxt "ForgotPassword"
+msgid "Type a new password"
+msgstr "新しいパスワードを入力してください"
+
+#: ../src/scenes/ForgotPassword.rb:77
+msgctxt "ForgotPassword"
+msgid "Type a new password again"
+msgstr "新しいパスワードを再入力してください"
+
+#: ../src/scenes/ForgotPassword.rb:80
+msgctxt "ForgotPassword"
+msgid "The entered passwords are different."
+msgstr "入力されたパスワードが一致しません。"
+
+#: ../src/scenes/ForgotPassword.rb:82
+msgctxt "ForgotPassword"
+msgid "Empty password provided."
+msgstr "パスワードが入力されていません。"
+
+#: ../src/scenes/ForgotPassword.rb:87
+msgctxt "ForgotPassword"
+msgid "Please wait while the password is being changed"
+msgstr "パスワードを変更しています。お待ちください。"
+
+#: ../src/scenes/ForgotPassword.rb:93
+msgctxt "ForgotPassword"
+msgid "The password has been changed. You can log in to your account using the new data."
+msgstr "パスワードが変更されました。新しい情報を使用してアカウントにログインできます。"
+
+#: ../src/scenes/Forum.rb:93
+msgctxt "Forum"
+msgid "Sort"
+msgstr "並べ替え"
+
+#: ../src/scenes/Forum.rb:94
+msgctxt "Forum"
+msgid "Default"
+msgstr "デフォルト"
+
+#: ../src/scenes/Forum.rb:95
+msgctxt "Forum"
+msgid "By name (ascending)"
+msgstr "名前順（昇順）"
+
+#: ../src/scenes/Forum.rb:96
+msgctxt "Forum"
+msgid "By name (descending)"
+msgstr "名前順（降順）"
+
+#: ../src/scenes/Forum.rb:97
+msgctxt "Forum"
+msgid "By unread posts (ascending)"
+msgstr "未読投稿数順（昇順）"
+
+#: ../src/scenes/Forum.rb:98
+msgctxt "Forum"
+msgid "By unread posts (descending)"
+msgstr "未読投稿数順（降順）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Awaiting group invitation"
+msgid_plural "Awaiting group invitations (%{count})"
+msgstr[0] "保留中のグループ招待（%{count}）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Open groups (%{count})"
+msgstr "公開グループ（%{count}）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Recommended groups (%{count})"
+msgstr "おすすめのグループ（%{count}）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "All groups (%{count})"
+msgstr "すべてのグループ（%{count}）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Marked thread"
+msgid_plural "Marked threads"
+msgstr[0] "マークされたスレッド"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Followed forum"
+msgid_plural "Followed forums"
+msgstr[0] "フォロー中のフォーラム"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Followed thread"
+msgid_plural "Followed threads"
+msgstr[0] "フォロー中のスレッド"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Moderated group"
+msgid_plural "Moderated groups (%{count})"
+msgstr[0] "モデレート中のグループ（%{count}）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Recently active groups"
+msgstr "最近アクティブなグループ"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Thread offered to my group"
+msgid_plural "Threads offered to my groups (%{count})"
+msgstr[0] "自分のグループに提供されたスレッド（%{count}）"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "My threads"
+msgstr "自分のスレッド"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Received mentions"
+msgstr "受信したメンション"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Threads popular with my friends"
+msgstr "友達に人気のスレッド"
+
+#: ../src/scenes/Forum.rb:212 ../src/scenes/Forum.rb:497 ../src/scenes/Forum.rb:1304 ../src/scenes/Forum.rb:1566
+msgctxt "Forum"
+msgid "Search"
+msgstr "検索"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Groups popular with my friends"
+msgstr "友達に人気のグループ"
+
+#: ../src/scenes/Forum.rb:212
+msgctxt "Forum"
+msgid "Recently created groups"
+msgstr "最近作成されたグループ"
+
+#: ../src/scenes/Forum.rb:220 ../src/scenes/Forum.rb:245 ../src/scenes/Forum.rb:266 ../src/scenes/Forum.rb:288 ../src/scenes/Forum.rb:308 ../src/scenes/Forum.rb:328 ../src/scenes/Forum.rb:349 ../src/scenes/Forum.rb:365 ../src/scenes/Forum.rb:385
+#: ../src/scenes/Forum.rb:1391 ../src/scenes/Forum.rb:1987
+msgctxt "Forum"
+msgid "posts"
+msgstr "投稿"
+
+#: ../src/scenes/Forum.rb:220 ../src/scenes/Forum.rb:245 ../src/scenes/Forum.rb:266 ../src/scenes/Forum.rb:288 ../src/scenes/Forum.rb:308 ../src/scenes/Forum.rb:328 ../src/scenes/Forum.rb:349 ../src/scenes/Forum.rb:365 ../src/scenes/Forum.rb:385
+#: ../src/scenes/Forum.rb:1391 ../src/scenes/Forum.rb:1987
+msgctxt "Forum"
+msgid "Unread"
+msgstr "未読"
+
+#: ../src/scenes/Forum.rb:220 ../src/scenes/Forum.rb:245 ../src/scenes/Forum.rb:266 ../src/scenes/Forum.rb:288 ../src/scenes/Forum.rb:308 ../src/scenes/Forum.rb:328 ../src/scenes/Forum.rb:349 ../src/scenes/Forum.rb:365 ../src/scenes/Forum.rb:385
+msgctxt "Forum"
+msgid "Forums"
+msgstr "フォーラム"
+
+#: ../src/scenes/Forum.rb:220 ../src/scenes/Forum.rb:245 ../src/scenes/Forum.rb:266 ../src/scenes/Forum.rb:288 ../src/scenes/Forum.rb:308 ../src/scenes/Forum.rb:328 ../src/scenes/Forum.rb:349 ../src/scenes/Forum.rb:365 ../src/scenes/Forum.rb:385
+#: ../src/scenes/Forum.rb:1391 ../src/scenes/Forum.rb:2303
+msgctxt "Forum"
+msgid "Threads"
+msgstr "スレッド"
+
+#: ../src/scenes/Forum.rb:245 ../src/scenes/Forum.rb:288 ../src/scenes/Forum.rb:308 ../src/scenes/Forum.rb:328 ../src/scenes/Forum.rb:349 ../src/scenes/Forum.rb:365 ../src/scenes/Forum.rb:385 ../src/scenes/Forum.rb:1063
+msgctxt "Forum"
+msgid "Administrator"
+msgstr "管理者"
+
+#: ../src/scenes/Forum.rb:393 ../src/scenes/Forum.rb:396 ../src/scenes/Forum.rb:939 ../src/scenes/Forum.rb:1395 ../src/scenes/Forum.rb:1593 ../src/scenes/Forum.rb:1991 ../src/scenes/Forum.rb:2472 ../src/scenes/Forum.rb:3182
+msgctxt "Forum"
+msgid "Forum"
+msgstr "フォーラム"
+
+#: ../src/scenes/Forum.rb:471 ../src/scenes/Forum.rb:1535 ../src/scenes/Forum.rb:2038
+msgctxt "Forum"
+msgid "Open"
+msgstr "開く"
+
+#: ../src/scenes/Forum.rb:475
+msgctxt "Forum"
+msgid "Show all threads"
+msgstr "すべてのスレッドを表示"
+
+#: ../src/scenes/Forum.rb:481
+msgctxt "Forum"
+msgid "Pin this group"
+msgstr "このグループをピン留め"
+
+#: ../src/scenes/Forum.rb:482
+msgctxt "Forum"
+msgid "Unpin this group"
+msgstr "このグループのピン留めを解除"
+
+#: ../src/scenes/Forum.rb:491
+msgctxt "Forum"
+msgid "Group has been pinned"
+msgstr "グループがピン留めされました"
+
+#: ../src/scenes/Forum.rb:493
+msgctxt "Forum"
+msgid "Group has been unpinned"
+msgstr "グループのピン留めが解除されました"
+
+#: ../src/scenes/Forum.rb:507
+msgctxt "Forum"
+msgid "Group blog"
+msgstr "グループブログ"
+
+#: ../src/scenes/Forum.rb:511 ../src/scenes/Forum.rb:578
+msgctxt "Forum"
+msgid "Group summary"
+msgstr "グループの概要"
+
+#: ../src/scenes/Forum.rb:514 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4366
+msgctxt "Forum"
+msgid "Language"
+msgstr "言語"
+
+#: ../src/scenes/Forum.rb:515 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4368
+msgctxt "Forum"
+msgid "Hidden"
+msgstr "非公開"
+
+#: ../src/scenes/Forum.rb:516 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4368
+msgctxt "Forum"
+msgid "Public"
+msgstr "公開"
+
+#: ../src/scenes/Forum.rb:520 ../src/scenes/Forum.rb:1278 ../src/scenes/Forum.rb:4417
+msgctxt "Forum"
+msgid "closed (only invited users can join)"
+msgstr "クローズド（招待されたユーザーのみ参加可能）"
+
+#: ../src/scenes/Forum.rb:522 ../src/scenes/Forum.rb:526 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:1278 ../src/scenes/Forum.rb:1280 ../src/scenes/Forum.rb:4417 ../src/scenes/Forum.rb:4419
+msgctxt "Forum"
+msgid "Moderated (everyone can request)"
+msgstr "モデレート（誰でも参加をリクエスト可能）"
+
+#: ../src/scenes/Forum.rb:528 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:1280 ../src/scenes/Forum.rb:4419
+msgctxt "Forum"
+msgid "open (everyone can join)"
+msgstr "オープン（誰でも参加可能）"
+
+#: ../src/scenes/Forum.rb:532
+msgctxt "Forum"
+msgid "Recommended"
+msgstr "おすすめ"
+
+#: ../src/scenes/Forum.rb:534 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4368
+msgctxt "Forum"
+msgid "Group type"
+msgstr "グループの種類"
+
+#: ../src/scenes/Forum.rb:535 ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4369
+msgctxt "Forum"
+msgid "Group join type"
+msgstr "グループ参加タイプ"
+
+#: ../src/scenes/Forum.rb:536 ../src/scenes/Forum.rb:1044
+msgctxt "Forum"
+msgid "Members"
+msgstr "メンバー"
+
+#: ../src/scenes/Forum.rb:537
+msgctxt "Forum"
+msgid "Founder"
+msgstr "創設者"
+
+#: ../src/scenes/Forum.rb:540
+msgctxt "Forum"
+msgid "Founded at"
+msgstr "設立日"
+
+#: ../src/scenes/Forum.rb:543
+msgctxt "Forum"
+msgid "The most active members"
+msgstr "最も活発なメンバー"
+
+#: ../src/scenes/Forum.rb:547
+msgctxt "Forum"
+msgid "Group size"
+msgstr "グループの規模"
+
+#: ../src/scenes/Forum.rb:557
+msgctxt "Forum"
+msgid "Audio posts"
+msgstr "音声投稿"
+
+#: ../src/scenes/Forum.rb:559 ../src/scenes/Forum.rb:2576 ../src/scenes/Forum.rb:3042 ../src/scenes/Forum.rb:3132 ../src/scenes/Forum.rb:3839
+msgctxt "Forum"
+msgid "Attachments"
+msgstr "添付ファイル"
+
+#: ../src/scenes/Forum.rb:561
+msgctxt "Forum"
+msgid "Text"
+msgstr "テキスト"
+
+#: ../src/scenes/Forum.rb:563
+msgctxt "Forum"
+msgid "Overall size"
+msgstr "全体のサイズ"
+
+#: ../src/scenes/Forum.rb:582 ../src/scenes/Forum.rb:4428
+msgctxt "Forum"
+msgid "Group regulations"
+msgstr "グループ規則"
+
+#: ../src/scenes/Forum.rb:583
+msgctxt "Forum"
+msgid "Edit group regulations"
+msgstr "グループ規則を編集"
+
+#: ../src/scenes/Forum.rb:589
+msgctxt "Forum"
+msgid "Show reported posts"
+msgstr "報告された投稿を表示"
+
+#: ../src/scenes/Forum.rb:594
+msgctxt "Forum"
+msgid "Message of the day"
+msgstr "本日のメッセージ"
+
+#: ../src/scenes/Forum.rb:595
+msgctxt "Forum"
+msgid "Edit message of the day"
+msgstr "本日のメッセージを編集"
+
+#: ../src/scenes/Forum.rb:600
+msgctxt "Forum"
+msgid "Group members"
+msgstr "グループメンバー"
+
+#: ../src/scenes/Forum.rb:604
+msgctxt "Forum"
+msgid "Join"
+msgstr "参加"
+
+#: ../src/scenes/Forum.rb:605
+msgctxt "Forum"
+msgid "Accept invitation"
+msgstr "招待を受け入れる"
+
+#: ../src/scenes/Forum.rb:606
+msgctxt "Forum"
+msgid "Ask to be enrolled in this group"
+msgstr "このグループへの参加をリクエスト"
+
+#: ../src/scenes/Forum.rb:611
+msgctxt "Forum"
+msgid "Do you wish to ask to be enrolled in %{groupname}"
+msgstr "%{groupname} への参加をリクエストしますか？"
+
+#: ../src/scenes/Forum.rb:613
+msgctxt "Forum"
+msgid "Are you sure you want to join %{groupname}?"
+msgstr "%{groupname} に参加してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:619
+msgctxt "Forum"
+msgid "Request sent"
+msgstr "リクエストが送信されました"
+
+#: ../src/scenes/Forum.rb:622
+msgctxt "Forum"
+msgid "You've just joined the group"
+msgstr "グループに参加しました"
+
+#: ../src/scenes/Forum.rb:634
+msgctxt "Forum"
+msgid "Add this group to quick actions"
+msgstr "このグループをクイックアクションに追加"
+
+#: ../src/scenes/Forum.rb:635 ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "Group"
+msgstr "グループ"
+
+#: ../src/scenes/Forum.rb:636
+msgctxt "Forum"
+msgid "Group added to quick actions"
+msgstr "グループがクイックアクションに追加されました"
+
+#: ../src/scenes/Forum.rb:640
+msgctxt "Forum"
+msgid "Leave"
+msgstr "退出"
+
+#: ../src/scenes/Forum.rb:641
+msgctxt "Forum"
+msgid "Refuse invitation"
+msgstr "招待を拒否"
+
+#: ../src/scenes/Forum.rb:644
+msgctxt "Forum"
+msgid "Are you sure you want to leave %{groupname}?"
+msgstr "%{groupname} を退出してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:647
+msgctxt "Forum"
+msgid "You've just left the group"
+msgstr "グループを退出しました"
+
+#: ../src/scenes/Forum.rb:656
+msgctxt "Forum"
+msgid "Mark this group as read"
+msgstr "このグループを既読としてマーク"
+
+#: ../src/scenes/Forum.rb:657
+msgctxt "Forum"
+msgid "All posts in this group will be marked as read. Are you sure you want to continue?"
+msgstr "このグループのすべての投稿が既読としてマークされます。続行しますか？"
+
+#: ../src/scenes/Forum.rb:668
+msgctxt "Forum"
+msgid "The group has been marked as read."
+msgstr "グループが既読としてマークされました。"
+
+#: ../src/scenes/Forum.rb:675
+msgctxt "Forum"
+msgid "Edit group"
+msgstr "グループを編集"
+
+#: ../src/scenes/Forum.rb:679
+msgctxt "Forum"
+msgid "Administrative log"
+msgstr "管理ログ"
+
+#: ../src/scenes/Forum.rb:686
+msgctxt "Forum"
+msgid "Delete group"
+msgstr "グループを削除"
+
+#: ../src/scenes/Forum.rb:687
+msgctxt "Forum"
+msgid "Are you sure you want to delete %{groupname}?"
+msgstr "%{groupname} を削除してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:692
+msgctxt "Forum"
+msgid "Group has been deleted"
+msgstr "グループが削除されました"
+
+#: ../src/scenes/Forum.rb:701
+msgctxt "Forum"
+msgid "Show groups in unknown languages"
+msgstr "未知の言語のグループを表示"
+
+#: ../src/scenes/Forum.rb:702
+msgctxt "Forum"
+msgid "Hide groups in unknown languages"
+msgstr "未知の言語のグループを非表示"
+
+#: ../src/scenes/Forum.rb:713 ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "New group"
+msgstr "新しいグループ"
+
+#: ../src/scenes/Forum.rb:736
+msgctxt "Forum"
+msgid "Message of the day of group %{groupname}"
+msgstr "グループ %{groupname} の本日のメッセージ"
+
+#: ../src/scenes/Forum.rb:750
+msgctxt "Forum"
+msgid "Message of the day updated"
+msgstr "本日のメッセージが更新されました"
+
+#: ../src/scenes/Forum.rb:762 ../src/scenes/Forum.rb:1239 ../src/scenes/Forum.rb:3082
+msgctxt "Forum"
+msgid "Regulations of group %{groupname}"
+msgstr "グループ %{groupname} の規則"
+
+#: ../src/scenes/Forum.rb:775
+msgctxt "Forum"
+msgid "Regulations updated"
+msgstr "規則が更新されました"
+
+#: ../src/scenes/Forum.rb:786 ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "Thread"
+msgstr "スレッド"
+
+#: ../src/scenes/Forum.rb:786
+msgctxt "Forum"
+msgid "Reported at"
+msgstr "報告日時"
+
+#: ../src/scenes/Forum.rb:786 ../src/scenes/Forum.rb:907
+msgctxt "Forum"
+msgid "Status"
+msgstr "ステータス"
+
+#: ../src/scenes/Forum.rb:786
+msgctxt "Forum"
+msgid "Comment"
+msgstr "コメント"
+
+#: ../src/scenes/Forum.rb:786
+msgctxt "Forum"
+msgid "Reported by"
+msgstr "報告者"
+
+#: ../src/scenes/Forum.rb:787
+msgctxt "Forum"
+msgid "Reported posts"
+msgstr "報告された投稿"
+
+#: ../src/scenes/Forum.rb:838
+msgctxt "Forum"
+msgid "Solved"
+msgstr "解決済み"
+
+#: ../src/scenes/Forum.rb:839
+msgctxt "Forum"
+msgid "Unsolved"
+msgstr "未解決"
+
+#: ../src/scenes/Forum.rb:843 ../src/scenes/Forum.rb:907
+msgctxt "Forum"
+msgid "Rejected"
+msgstr "却下"
+
+#: ../src/scenes/Forum.rb:845 ../src/scenes/Forum.rb:907
+msgctxt "Forum"
+msgid "Accepted"
+msgstr "受理"
+
+#: ../src/scenes/Forum.rb:863
+msgctxt "Forum"
+msgid "Show reported post"
+msgstr "報告された投稿を表示"
+
+#: ../src/scenes/Forum.rb:864 ../src/scenes/Forum.rb:896
+msgctxt "Forum"
+msgid "Post"
+msgstr "投稿"
+
+#: ../src/scenes/Forum.rb:867
+msgctxt "Forum"
+msgid "Go to reported post"
+msgstr "報告された投稿へ移動"
+
+#: ../src/scenes/Forum.rb:870
+msgctxt "Forum"
+msgid "The searched thread has been already deleted."
+msgstr "検索したスレッドはすでに削除されています。"
+
+#: ../src/scenes/Forum.rb:877 ../src/scenes/Forum.rb:909
+msgctxt "Forum"
+msgid "Resolve"
+msgstr "解決"
+
+#: ../src/scenes/Forum.rb:884
+msgctxt "Forum"
+msgid "Refresh"
+msgstr "更新"
+
+#: ../src/scenes/Forum.rb:908
+msgctxt "Forum"
+msgid "Reason"
+msgstr "理由"
+
+#: ../src/scenes/Forum.rb:918
+msgctxt "Forum"
+msgid "Do you want to send information about status of this report to its author?"
+msgstr "この報告のステータスに関する情報を報告者に送信しますか？"
+
+#: ../src/scenes/Forum.rb:929
+msgctxt "Forum"
+msgid "Report resolved"
+msgstr "報告が解決されました"
+
+#: ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "Action"
+msgstr "アクション"
+
+#: ../src/scenes/Forum.rb:939 ../src/scenes/Forum.rb:1601
+msgctxt "Forum"
+msgid "New forum"
+msgstr "新しいフォーラム"
+
+#: ../src/scenes/Forum.rb:939 ../src/scenes/Forum.rb:2102
+msgctxt "Forum"
+msgid "New thread"
+msgstr "新しいスレッド"
+
+#: ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "Old status"
+msgstr "旧ステータス"
+
+#: ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "New status"
+msgstr "新しいステータス"
+
+#: ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "Time"
+msgstr "時間"
+
+#: ../src/scenes/Forum.rb:939
+msgctxt "Forum"
+msgid "Log"
+msgstr "ログ"
+
+#: ../src/scenes/Forum.rb:969
+msgctxt "Forum"
+msgid "Thread deletion"
+msgstr "スレッドの削除"
+
+#: ../src/scenes/Forum.rb:971
+msgctxt "Forum"
+msgid "Post deletion"
+msgstr "投稿の削除"
+
+#: ../src/scenes/Forum.rb:973
+msgctxt "Forum"
+msgid "Post edit"
+msgstr "投稿の編集"
+
+#: ../src/scenes/Forum.rb:975
+msgctxt "Forum"
+msgid "Thread move"
+msgstr "スレッドの移動"
+
+#: ../src/scenes/Forum.rb:977
+msgctxt "Forum"
+msgid "Post move"
+msgstr "投稿の移動"
+
+#: ../src/scenes/Forum.rb:979
+msgctxt "Forum"
+msgid "Thread rename"
+msgstr "スレッドの名前変更"
+
+#: ../src/scenes/Forum.rb:981
+msgctxt "Forum"
+msgid "Thread offer"
+msgstr "スレッドの提供"
+
+#: ../src/scenes/Forum.rb:1065
+msgctxt "Forum"
+msgid "Moderator"
+msgstr "モデレーター"
+
+#: ../src/scenes/Forum.rb:1067 ../src/scenes/Forum.rb:3126
+msgctxt "Forum"
+msgid "Banned"
+msgstr "禁止中"
+
+#: ../src/scenes/Forum.rb:1069
+msgctxt "Forum"
+msgid "Invited"
+msgstr "招待済み"
+
+#: ../src/scenes/Forum.rb:1071
+msgctxt "Forum"
+msgid "Waiting for review"
+msgstr "審査待ち"
+
+#: ../src/scenes/Forum.rb:1086 ../src/scenes/Forum.rb:1096
+msgctxt "Forum"
+msgid "Privileges of this user have been changed."
+msgstr "このユーザーの権限が変更されました。"
+
+#: ../src/scenes/Forum.rb:1108
+msgctxt "Forum"
+msgid "Grant moderation privileges"
+msgstr "モデレーション権限を付与"
+
+#: ../src/scenes/Forum.rb:1109
+msgctxt "Forum"
+msgid "You want to give the role of moderator to a user who is banned globally. Groups with banned moderators are not displayed in most lists. Are you sure you want to continue?"
+msgstr "グローバルに禁止されているユーザーにモデレーターの役割を与えようとしています。禁止されたモデレーターを持つグループはほとんどのリストに表示されません。それでも続行しますか？"
+
+#: ../src/scenes/Forum.rb:1114
+msgctxt "Forum"
+msgid "Deny moderation privileges"
+msgstr "モデレーション権限を取り消す"
+
+#: ../src/scenes/Forum.rb:1115
+msgctxt "Forum"
+msgid "Pass administrative privileges"
+msgstr "管理者権限を譲渡する"
+
+#: ../src/scenes/Forum.rb:1116
+msgctxt "Forum"
+msgid "Are you sure you want to resign your administrative privileges in %{groupname} and pass them to %{user}?"
+msgstr "%{groupname} の管理者権限を辞退し、%{user} に譲渡してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1124
+msgctxt "Forum"
+msgid "Enable inheritance of this users' role"
+msgstr "このユーザーの役割の継承を有効にする"
+
+#: ../src/scenes/Forum.rb:1125
+msgctxt "Forum"
+msgid "Disable inheritance of this users' role"
+msgstr "このユーザーの役割の継承を無効にする"
+
+#: ../src/scenes/Forum.rb:1151
+msgctxt "Forum"
+msgid "Ban in this group"
+msgstr "このグループで禁止する"
+
+#: ../src/scenes/Forum.rb:1152
+msgctxt "Forum"
+msgid "Are you sure you want to ban %{user} in %{groupname}?"
+msgstr "%{groupname} で %{user} を禁止してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1155
+msgctxt "Forum"
+msgid "Kick"
+msgstr "キックする"
+
+#: ../src/scenes/Forum.rb:1156
+msgctxt "Forum"
+msgid "Are you sure you want to kick %{user} out of %{groupname}?"
+msgstr "%{groupname} から %{user} をキックしてもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1160
+msgctxt "Forum"
+msgid "Unban"
+msgstr "禁止解除"
+
+#: ../src/scenes/Forum.rb:1161
+msgctxt "Forum"
+msgid "Are you sure you want to unban %{user} in %{groupname}?"
+msgstr "%{groupname} で %{user} の禁止を解除してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1164
+msgctxt "Forum"
+msgid "Accept"
+msgstr "承認"
+
+#: ../src/scenes/Forum.rb:1165
+msgctxt "Forum"
+msgid "Do you want to accept request of user %{user}"
+msgstr "%{user} のリクエストを承認しますか？"
+
+#: ../src/scenes/Forum.rb:1167
+msgctxt "Forum"
+msgid "Refuse"
+msgstr "拒否"
+
+#: ../src/scenes/Forum.rb:1168
+msgctxt "Forum"
+msgid "Do you want to refuse request of user %{user}"
+msgstr "%{user} のリクエストを拒否しますか？"
+
+#: ../src/scenes/Forum.rb:1171
+msgctxt "Forum"
+msgid "Cancel invitation"
+msgstr "招待をキャンセル"
+
+#: ../src/scenes/Forum.rb:1172
+msgctxt "Forum"
+msgid "Are you sure you want to cancel invitation of %{user} to %{groupname}?"
+msgstr "%{groupname} への %{user} の招待をキャンセルしてもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1179
+msgctxt "Forum"
+msgid "Invite"
+msgstr "招待する"
+
+#: ../src/scenes/Forum.rb:1180
+msgctxt "Forum"
+msgid "Add user"
+msgstr "ユーザーを追加"
+
+#: ../src/scenes/Forum.rb:1182
+msgctxt "Forum"
+msgid "User to invite"
+msgstr "招待するユーザー"
+
+#: ../src/scenes/Forum.rb:1187
+msgctxt "Forum"
+msgid "The user has been invited"
+msgstr "ユーザーが招待されました"
+
+#: ../src/scenes/Forum.rb:1193 ../src/scenes/Messages.rb:1070 ../src/scenes/Users.rb:21
+msgid "You haven't permissions to do this"
+msgstr "この操作を行う権限がありません"
+
+#: ../src/scenes/Forum.rb:1195
+msgctxt "Forum"
+msgid "This user does not exist"
+msgstr "このユーザーは存在しません"
+
+#: ../src/scenes/Forum.rb:1197
+msgctxt "Forum"
+msgid "This user already belongs to this group"
+msgstr "このユーザーはすでにこのグループに所属しています"
+
+#: ../src/scenes/Forum.rb:1240 ../src/scenes/Forum.rb:3083
+msgctxt "Forum"
+msgid "I accept regulations of group %{groupname}"
+msgstr "私はグループ %{groupname} の規則に同意します"
+
+#: ../src/scenes/Forum.rb:1241 ../src/scenes/Forum.rb:3084
+msgctxt "Forum"
+msgid "I decline regulations of group %{groupname}"
+msgstr "私はグループ %{groupname} の規則に同意しません"
+
+#: ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4357
+msgctxt "Forum"
+msgid "Group description"
+msgstr "グループの説明"
+
+#: ../src/scenes/Forum.rb:1266 ../src/scenes/Forum.rb:4356
+msgctxt "Forum"
+msgid "Group name"
+msgstr "グループ名"
+
+#: ../src/scenes/Forum.rb:1272
+msgctxt "Forum"
+msgid "Create group"
+msgstr "グループを作成"
+
+#: ../src/scenes/Forum.rb:1287
+msgctxt "Forum"
+msgid "Group has been created"
+msgstr "グループが作成されました"
+
+#: ../src/scenes/Forum.rb:1300
+msgctxt "Forum"
+msgid "Search query"
+msgstr "検索クエリ"
+
+#: ../src/scenes/Forum.rb:1301
+msgctxt "Forum"
+msgid "Content"
+msgstr "内容"
+
+#: ../src/scenes/Forum.rb:1301
+msgctxt "Forum"
+msgid "Authors"
+msgstr "著者"
+
+#: ../src/scenes/Forum.rb:1301
+msgctxt "Forum"
+msgid "Search in"
+msgstr "検索対象"
+
+#: ../src/scenes/Forum.rb:1301
+msgctxt "Forum"
+msgid "Titles"
+msgstr "タイトル"
+
+#: ../src/scenes/Forum.rb:1302
+msgctxt "Forum"
+msgid "Joined groups"
+msgstr "参加中のグループ"
+
+#: ../src/scenes/Forum.rb:1302
+msgctxt "Forum"
+msgid "Recommended groups"
+msgstr "おすすめのグループ"
+
+#: ../src/scenes/Forum.rb:1302
+msgctxt "Forum"
+msgid "Not joined groups"
+msgstr "未参加のグループ"
+
+#: ../src/scenes/Forum.rb:1302
+msgctxt "Forum"
+msgid "of threads in"
+msgstr "のスレッド内"
+
+#: ../src/scenes/Forum.rb:1303
+msgctxt "Forum"
+msgid "Include transcriptions of audio posts"
+msgstr "音声投稿の文字起こしを含める"
+
+#: ../src/scenes/Forum.rb:1392
+msgctxt "Forum"
+msgid "Select forum"
+msgstr "フォーラムを選択"
+
+#: ../src/scenes/Forum.rb:1420
+msgctxt "Forum"
+msgid "Forum tags"
+msgstr "フォーラムのタグ"
+
+#: ../src/scenes/Forum.rb:1422
+msgctxt "Forum"
+msgid "New tag"
+msgstr "新しいタグ"
+
+#: ../src/scenes/Forum.rb:1435
+msgctxt "Forum"
+msgid "Delete tag"
+msgstr "タグを削除"
+
+#: ../src/scenes/Forum.rb:1436
+msgctxt "Forum"
+msgid "Are you sure you want to delete this tag?"
+msgstr "このタグを削除してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1462
+msgctxt "Forum"
+msgid "Tag name"
+msgstr "タグ名"
+
+#: ../src/scenes/Forum.rb:1463
+msgctxt "Forum"
+msgid "Possible tag values"
+msgstr "可能なタグの値"
+
+#: ../src/scenes/Forum.rb:1469
+msgctxt "Forum"
+msgid "Add tag value"
+msgstr "タグの値を追加"
+
+#: ../src/scenes/Forum.rb:1470 ../src/scenes/Forum.rb:1483
+msgctxt "Forum"
+msgid "Tag value"
+msgstr "タグの値"
+
+#: ../src/scenes/Forum.rb:1472 ../src/scenes/Forum.rb:1485
+msgctxt "Forum"
+msgid "Tag values cannot contain punctuation characters"
+msgstr "タグの値には句読点を含めることはできません"
+
+#: ../src/scenes/Forum.rb:1482
+msgctxt "Forum"
+msgid "Edit tag value"
+msgstr "タグの値を編集"
+
+#: ../src/scenes/Forum.rb:1494
+msgctxt "Forum"
+msgid "Delete tag value"
+msgstr "タグの値を削除"
+
+#: ../src/scenes/Forum.rb:1511
+msgctxt "Forum"
+msgid "Tag must have at least one value"
+msgstr "タグには少なくとも1つの値が必要です"
+
+#: ../src/scenes/Forum.rb:1539
+msgctxt "Forum"
+msgid "Follow this forum"
+msgstr "このフォーラムをフォロー"
+
+#: ../src/scenes/Forum.rb:1540
+msgctxt "Forum"
+msgid "Unfollow this forum"
+msgstr "このフォーラムのフォローをやめる"
+
+#: ../src/scenes/Forum.rb:1547
+msgctxt "Forum"
+msgid "Added to followed forums list."
+msgstr "フォロー中のフォーラムリストに追加されました。"
+
+#: ../src/scenes/Forum.rb:1554
+msgctxt "Forum"
+msgid "Removed from followed forums list."
+msgstr "フォロー中のフォーラムリストから削除されました。"
+
+#: ../src/scenes/Forum.rb:1575
+msgctxt "Forum"
+msgid "Mark this forum as read"
+msgstr "このフォーラムを既読としてマーク"
+
+#: ../src/scenes/Forum.rb:1576
+msgctxt "Forum"
+msgid "All posts on this forum will be marked as read. Are you sure you want to continue?"
+msgstr "このフォーラムのすべての投稿が既読としてマークされます。続行してもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:1586
+msgctxt "Forum"
+msgid "The forum has been marked as read."
+msgstr "フォーラムが既読としてマークされました。"
+
+#: ../src/scenes/Forum.rb:1592
+msgctxt "Forum"
+msgid "Add this forum to quick actions"
+msgstr "このフォーラムをクイックアクションに追加"
+
+#: ../src/scenes/Forum.rb:1594
+msgctxt "Forum"
+msgid "Forum added to quick actions"
+msgstr "フォーラムがクイックアクションに追加されました"
+
+#: ../src/scenes/Forum.rb:1600 ../src/scenes/Forum.rb:2110 ../src/scenes/Forum.rb:3519
+msgctxt "Forum"
+msgid "Moderation"
+msgstr "モデレーション"
+
+#: ../src/scenes/Forum.rb:1607
+msgctxt "Forum"
+msgid "Edit forum"
+msgstr "フォーラムを編集"
+
+#: ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+msgctxt "Forum"
+msgid "Forum name"
+msgstr "フォーラム名"
+
+#: ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+msgctxt "Forum"
+msgid "Forum type"
+msgstr "フォーラムの種類"
+
+#: ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+msgctxt "Forum"
+msgid "Mixed forum"
+msgstr "混合フォーラム"
+
+#: ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+msgctxt "Forum"
+msgid "Voice forum"
+msgstr "音声フォーラム"
+
+#: ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+msgctxt "Forum"
+msgid "Text forum"
+msgstr "テキストフォーラム"
+
+#: ../src/scenes/Forum.rb:1608 ../src/scenes/Forum.rb:1708
+msgctxt "Forum"
+msgid "Forum description"
+msgstr "フォーラムの説明"
+
+#: ../src/scenes/Forum.rb:1642
+msgctxt "Forum"
+msgid "Close forum"
+msgstr "フォーラムを閉鎖する"
+
+#: ../src/scenes/Forum.rb:1643
+msgctxt "Forum"
+msgid "Open forum"
+msgstr "フォーラムを再開する"
+
+#: ../src/scenes/Forum.rb:1653
+msgctxt "Forum"
+msgid "The forum has been opened"
+msgstr "フォーラムを再開しました"
+
+#: ../src/scenes/Forum.rb:1657
+msgctxt "Forum"
+msgid "The forum has been closed"
+msgstr "フォーラムを閉鎖しました"
+
+#: ../src/scenes/Forum.rb:1662
+msgctxt "Forum"
+msgid "Edit forum tags"
+msgstr "フォーラムのタグを編集"
+
+#: ../src/scenes/Forum.rb:1666
+msgctxt "Forum"
+msgid "Change forum position"
+msgstr "フォーラムの位置を変更"
+
+#: ../src/scenes/Forum.rb:1669
+msgctxt "Forum"
+msgid "Move forum"
+msgstr "フォーラムを移動"
+
+#: ../src/scenes/Forum.rb:1669 ../src/scenes/Forum.rb:3618
+msgctxt "Forum"
+msgid "Move to end"
+msgstr "末尾に移動"
+
+#: ../src/scenes/Forum.rb:1684
+msgctxt "Forum"
+msgid "Delete forum"
+msgstr "フォーラムを削除"
+
+#: ../src/scenes/Forum.rb:1685
+msgctxt "Forum"
+msgid "Are you sure you want to delete this forum?"
+msgstr "本当にこのフォーラムを削除しますか？"
+
+#: ../src/scenes/Forum.rb:1690
+msgctxt "Forum"
+msgid "The forum has been deleted."
+msgstr "フォーラムが削除されました。"
+
+#: ../src/scenes/Forum.rb:1714
+msgctxt "Forum"
+msgid "Create forum"
+msgstr "フォーラムを作成"
+
+#: ../src/scenes/Forum.rb:1730
+msgctxt "Forum"
+msgid "The forum has been created"
+msgstr "フォーラムが作成されました。"
+
+#: ../src/scenes/Forum.rb:1940
+msgctxt "Forum"
+msgid "No new posts in followed threads"
+msgstr "フォロー中のスレッドに新しい投稿はありません"
+
+#: ../src/scenes/Forum.rb:1944
+msgctxt "Forum"
+msgid "No new threads on the followed forums"
+msgstr "フォロー中のフォーラムに新しいスレッドはありません"
+
+#: ../src/scenes/Forum.rb:1948
+msgctxt "Forum"
+msgid "No new posts on the followed forums"
+msgstr "フォロー中のフォーラムに新しい投稿はありません"
+
+#: ../src/scenes/Forum.rb:1952
+msgctxt "Forum"
+msgid "No new mentions"
+msgstr "新しいメンションはありません"
+
+#: ../src/scenes/Forum.rb:1966
+msgctxt "Forum"
+msgid "New"
+msgstr "新規"
+
+#: ../src/scenes/Forum.rb:1970
+msgctxt "Forum"
+msgid "Mentioned by"
+msgstr "メンションした人："
+
+#: ../src/scenes/Forum.rb:1985
+msgctxt "Forum"
+msgid "Select thread"
+msgstr "スレッドを選択"
+
+#: ../src/scenes/Forum.rb:1987
+msgctxt "Forum"
+msgid "Author"
+msgstr "作成者"
+
+#: ../src/scenes/Forum.rb:2041 ../src/scenes/Forum.rb:3468
+msgctxt "Forum"
+msgid "Mark this thread"
+msgstr "このスレッドをマーク"
+
+#: ../src/scenes/Forum.rb:2042 ../src/scenes/Forum.rb:3469
+msgctxt "Forum"
+msgid "Unmark this thread"
+msgstr "このスレッドのマークを外す"
+
+#: ../src/scenes/Forum.rb:2051 ../src/scenes/Forum.rb:3478
+msgctxt "Forum"
+msgid "Thread unmarked"
+msgstr "スレッドのマークを外しました"
+
+#: ../src/scenes/Forum.rb:2053 ../src/scenes/Forum.rb:3480
+msgctxt "Forum"
+msgid "Thread marked"
+msgstr "スレッドをマークしました"
+
+#: ../src/scenes/Forum.rb:2062 ../src/scenes/Forum.rb:2472 ../src/scenes/Forum.rb:3486
+msgctxt "Forum"
+msgid "Add to followed threads list"
+msgstr "フォロー中のスレッドに追加"
+
+#: ../src/scenes/Forum.rb:2063 ../src/scenes/Forum.rb:3487
+msgctxt "Forum"
+msgid "Unfollow this thread"
+msgstr "このスレッドのフォローを解除"
+
+#: ../src/scenes/Forum.rb:2069 ../src/scenes/Forum.rb:3493
+msgctxt "Forum"
+msgid "Added to the list of followed threads."
+msgstr "フォロー中のスレッドに追加されました。"
+
+#: ../src/scenes/Forum.rb:2076 ../src/scenes/Forum.rb:3500
+msgctxt "Forum"
+msgid "Removed from followed threads list."
+msgstr "フォロー中のスレッドから削除されました。"
+
+#: ../src/scenes/Forum.rb:2084
+msgctxt "Forum"
+msgid "Thread statistics"
+msgstr "スレッドの統計"
+
+#: ../src/scenes/Forum.rb:2088
+msgctxt "Forum"
+msgid "Followers: %{count_followers}"
+msgstr "フォロワー数：%{count_followers}"
+
+#: ../src/scenes/Forum.rb:2089
+msgctxt "Forum"
+msgid "All mentions: %{count_mentions}"
+msgstr "メンション総数：%{count_mentions}"
+
+#: ../src/scenes/Forum.rb:2090
+msgctxt "Forum"
+msgid "Unique authors: %{count_authors}"
+msgstr "ユニークな作成者数：%{count_authors}"
+
+#: ../src/scenes/Forum.rb:2091
+msgctxt "Forum"
+msgid "Readers: %{count_readers}"
+msgstr "読者数：%{count_readers}"
+
+#: ../src/scenes/Forum.rb:2092
+msgctxt "Forum"
+msgid "Users that have read less than 50 percent of posts: %{count_readers}"
+msgstr "投稿の50％未満を読んだユーザー数：%{count_readers}"
+
+#: ../src/scenes/Forum.rb:2093
+msgctxt "Forum"
+msgid "Users that have read over 90 percent of posts: %{count_readers}"
+msgstr "投稿の90％以上を読んだユーザー数：%{count_readers}"
+
+#: ../src/scenes/Forum.rb:2094
+msgctxt "Forum"
+msgid "Users that have read all posts: %{count_readers}"
+msgstr "すべての投稿を読んだユーザー数：%{count_readers}"
+
+#: ../src/scenes/Forum.rb:2096
+msgctxt "Forum"
+msgid "Thread statistics summary"
+msgstr "スレッド統計の概要"
+
+#: ../src/scenes/Forum.rb:2111
+msgctxt "Forum"
+msgid "Move thread"
+msgstr "スレッドを移動"
+
+#: ../src/scenes/Forum.rb:2122
+msgctxt "Forum"
+msgid "Thread destination"
+msgstr "スレッドの移動先"
+
+#: ../src/scenes/Forum.rb:2127
+msgctxt "Forum"
+msgid "The thread has been moved."
+msgstr "スレッドが移動されました。"
+
+#: ../src/scenes/Forum.rb:2134
+msgctxt "Forum"
+msgid "Rename"
+msgstr "名前を変更"
+
+#: ../src/scenes/Forum.rb:2135
+msgctxt "Forum"
+msgid "Type a new thread name"
+msgstr "新しいスレッド名を入力してください"
+
+#: ../src/scenes/Forum.rb:2140
+msgctxt "Forum"
+msgid "The forum name has been changed."
+msgstr "フォーラム名が変更されました。"
+
+#: ../src/scenes/Forum.rb:2147
+msgctxt "Forum"
+msgid "Delete thread"
+msgstr "スレッドを削除"
+
+#: ../src/scenes/Forum.rb:2148
+msgctxt "Forum"
+msgid "Do you really want to delete thread %{thrname}?"
+msgstr "本当にスレッド「%{thrname}」を削除しますか？"
+
+#: ../src/scenes/Forum.rb:2152
+msgctxt "Forum"
+msgid "This thread has been deleted."
+msgstr "このスレッドは削除されました。"
+
+#: ../src/scenes/Forum.rb:2159
+msgctxt "Forum"
+msgid "Close thread"
+msgstr "スレッドを閉鎖する"
+
+#: ../src/scenes/Forum.rb:2160
+msgctxt "Forum"
+msgid "Open thread"
+msgstr "スレッドを再開する"
+
+#: ../src/scenes/Forum.rb:2170
+msgctxt "Forum"
+msgid "The thread has been opened"
+msgstr "スレッドを再開しました"
+
+#: ../src/scenes/Forum.rb:2174
+msgctxt "Forum"
+msgid "The thread has been closed"
+msgstr "スレッドを閉鎖しました"
+
+#: ../src/scenes/Forum.rb:2179
+msgctxt "Forum"
+msgid "Pin thread"
+msgstr "スレッドを固定"
+
+#: ../src/scenes/Forum.rb:2180
+msgctxt "Forum"
+msgid "Unpin thread"
+msgstr "スレッドの固定を解除"
+
+#: ../src/scenes/Forum.rb:2190
+msgctxt "Forum"
+msgid "Thread has been unpinned"
+msgstr "スレッドの固定が解除されました"
+
+#: ../src/scenes/Forum.rb:2194
+msgctxt "Forum"
+msgid "Thread has been pinned"
+msgstr "スレッドが固定されました"
+
+#: ../src/scenes/Forum.rb:2200
+msgctxt "Forum"
+msgid "Offer this thread to another group"
+msgstr "このスレッドを別のグループに提供"
+
+#: ../src/scenes/Forum.rb:2212 ../src/scenes/Forum.rb:2420
+msgctxt "Forum"
+msgid "Group founded by %{founder}"
+msgstr "%{founder} によって設立されたグループ"
+
+#: ../src/scenes/Forum.rb:2213
+msgctxt "Forum"
+msgid "Which group you want to offer this thread to?"
+msgstr "このスレッドをどのグループに提供しますか？"
+
+#: ../src/scenes/Forum.rb:2220 ../src/scenes/Forum.rb:2428
+msgctxt "Forum"
+msgid "The offer has been created"
+msgstr "オファーが作成されました"
+
+#: ../src/scenes/Forum.rb:2227
+msgctxt "Forum"
+msgid "Withdraw the offer of this thread"
+msgstr "このスレッドのオファーを取り下げる"
+
+#: ../src/scenes/Forum.rb:2232
+msgctxt "Forum"
+msgid "The offer has been withdrawn."
+msgstr "オファーが取り下げられました。"
+
+#: ../src/scenes/Forum.rb:2238 ../src/scenes/Forum.rb:3630
+msgctxt "Forum"
+msgid "Mass Actions"
+msgstr "一括操作"
+
+#: ../src/scenes/Forum.rb:2253
+msgctxt "Forum"
+msgid "Thread transfer offer to group %{groupname}"
+msgstr "グループ %{groupname} へのスレッド移管オファー"
+
+#: ../src/scenes/Forum.rb:2254
+msgctxt "Forum"
+msgid "Accept this offer"
+msgstr "このオファーを受け入れる"
+
+#: ../src/scenes/Forum.rb:2260
+msgctxt "Forum"
+msgid "Select destination forum"
+msgstr "移動先のフォーラムを選択"
+
+#: ../src/scenes/Forum.rb:2269
+msgctxt "Forum"
+msgid "Offer accepted"
+msgstr "オファーが受け入れられました"
+
+#: ../src/scenes/Forum.rb:2278
+msgctxt "Forum"
+msgid "Refuse this offer"
+msgstr "このオファーを拒否する"
+
+#: ../src/scenes/Forum.rb:2283
+msgctxt "Forum"
+msgid "Offer refused"
+msgstr "オファーが拒否されました"
+
+#: ../src/scenes/Forum.rb:2304 ../src/scenes/Forum.rb:2361 ../src/scenes/Forum.rb:3644 ../src/scenes/Forum.rb:3688
+msgctxt "Forum"
+msgid "Move"
+msgstr "移動"
+
+#: ../src/scenes/Forum.rb:2305 ../src/scenes/Forum.rb:2367
+msgctxt "Forum"
+msgid "Offer"
+msgstr "オファー"
+
+#: ../src/scenes/Forum.rb:2306 ../src/scenes/Forum.rb:2364 ../src/scenes/Forum.rb:3645 ../src/scenes/Forum.rb:3691
+msgctxt "Forum"
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/scenes/Forum.rb:2353
+msgctxt "Forum"
+msgid "No threads selected"
+msgstr "スレッドが選択されていません"
+
+#: ../src/scenes/Forum.rb:2360 ../src/scenes/Forum.rb:2366
+msgctxt "Forum"
+msgid "%{count} thread to move"
+msgid_plural "%{count} threads to move"
+msgstr[0] "%{count} 件のスレッドを移動します"
+
+#: ../src/scenes/Forum.rb:2363
+msgctxt "Forum"
+msgid "%{count} thread to delete"
+msgid_plural "%{count} threads to delete"
+msgstr[0] "%{count} 件のスレッドを削除します"
+
+#: ../src/scenes/Forum.rb:2390
+msgctxt "Forum"
+msgid "Threads destination"
+msgstr "スレッドの移動先"
+
+#: ../src/scenes/Forum.rb:2395
+msgctxt "Forum"
+msgid "Selected threads have been moved."
+msgstr "選択したスレッドが移動されました。"
+
+#: ../src/scenes/Forum.rb:2405
+msgctxt "Forum"
+msgid "Selected threads have been deleted."
+msgstr "選択したスレッドが削除されました。"
+
+#: ../src/scenes/Forum.rb:2421
+msgctxt "Forum"
+msgid "Which group you want to offer these threads to?"
+msgstr "これらのスレッドをどのグループに提供しますか？"
+
+#: ../src/scenes/Forum.rb:2443 ../src/scenes/Forum.rb:2470 ../src/scenes/Forum.rb:3150 ../src/scenes/Forum.rb:3166
+msgctxt "Forum"
+msgid "Audio post"
+msgstr "音声投稿"
+
+#: ../src/scenes/Forum.rb:2443
+msgctxt "Forum"
+msgid "Select first post type"
+msgstr "最初の投稿タイプを選択"
+
+#: ../src/scenes/Forum.rb:2443 ../src/scenes/Forum.rb:3150
+msgctxt "Forum"
+msgid "Text post"
+msgstr "テキスト投稿"
+
+#: ../src/scenes/Forum.rb:2463
+msgctxt "Forum"
+msgid "Thread name"
+msgstr "スレッド名"
+
+#: ../src/scenes/Forum.rb:2465 ../src/scenes/Forum.rb:3162 ../src/scenes/Forum.rb:3839
+msgctxt "Forum"
+msgid "Use MarkDown in this post"
+msgstr "この投稿でMarkDownを使用"
+
+#: ../src/scenes/Forum.rb:2465
+msgctxt "Forum"
+msgid "Attach a poll"
+msgstr "投票を添付"
+
+#: ../src/scenes/Forum.rb:2465 ../src/scenes/Forum.rb:3161
+msgctxt "Forum"
+msgid "Attach a file"
+msgstr "ファイルを添付"
+
+#: ../src/scenes/Forum.rb:2465 ../src/scenes/Forum.rb:3643 ../src/scenes/Forum.rb:3695
+msgctxt "Forum"
+msgid "Post content"
+msgstr "投稿内容"
+
+#: ../src/scenes/Forum.rb:2479
+msgctxt "Forum"
+msgid "No tag value"
+msgstr "タグの値がありません"
+
+#: ../src/scenes/Forum.rb:2508 ../src/scenes/Forum.rb:2516 ../src/scenes/Forum.rb:3202 ../src/scenes/Forum.rb:3240
+msgctxt "Forum"
+msgid "Send"
+msgstr "送信"
+
+#: ../src/scenes/Forum.rb:2532
+msgctxt "Forum"
+msgid "Poll to attach"
+msgstr "添付する投票"
+
+#: ../src/scenes/Forum.rb:2537
+msgctxt "Forum"
+msgid "This poll has already been added"
+msgstr "この投票は既に追加されています"
+
+#: ../src/scenes/Forum.rb:2540 ../src/scenes/Forum.rb:3139
+msgctxt "Forum"
+msgid "Polls"
+msgstr "投票"
+
+#: ../src/scenes/Forum.rb:2542
+msgctxt "Forum"
+msgid "Poll has been added"
+msgstr "投票が追加されました"
+
+#: ../src/scenes/Forum.rb:2546
+msgctxt "Forum"
+msgid "You haven't created any polls yet."
+msgstr "まだ投票を作成していません。"
+
+#: ../src/scenes/Forum.rb:2567 ../src/scenes/Forum.rb:3033 ../src/scenes/Forum.rb:3848
+msgctxt "Forum"
+msgid "Select file to attach"
+msgstr "添付するファイルを選択"
+
+#: ../src/scenes/Forum.rb:2570 ../src/scenes/Forum.rb:3036
+msgctxt "Forum"
+msgid "This file has been already attached"
+msgstr "このファイルは既に添付されています"
+
+#: ../src/scenes/Forum.rb:2573 ../src/scenes/Forum.rb:3039 ../src/scenes/Forum.rb:3854
+msgctxt "Forum"
+msgid "This file is too large"
+msgstr "このファイルはサイズが大きすぎます"
+
+#: ../src/scenes/Forum.rb:2578 ../src/scenes/Forum.rb:3044
+msgctxt "Forum"
+msgid "The file has been attached"
+msgstr "ファイルが添付されました"
+
+#: ../src/scenes/Forum.rb:2611
+msgctxt "Forum"
+msgid "Are you sure you want to cancel creating this thread?"
+msgstr "このスレッドの作成をキャンセルしてもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:2678
+msgctxt "Forum"
+msgid "Thread has been created."
+msgstr "スレッドが作成されました。"
+
+#: ../src/scenes/Forum.rb:2680
+msgctxt "Forum"
+msgid "Error creating thread!"
+msgstr "スレッドの作成中にエラーが発生しました！"
+
+#: ../src/scenes/Forum.rb:2994
+msgctxt "Forum"
+msgid "Are you sure you want to cancel creating this post?"
+msgstr "この投稿の作成をキャンセルしてもよろしいですか？"
+
+#: ../src/scenes/Forum.rb:3013 ../src/scenes/Messages.rb:638 ../src/scenes/Polls.rb:24 ../src/scenes/Polls.rb:126
+msgctxt "Polls"
+msgid "Show results"
+msgstr "結果を表示"
+
+#: ../src/scenes/Forum.rb:3013 ../src/scenes/Messages.rb:638 ../src/scenes/Polls.rb:24 ../src/scenes/Polls.rb:129
+msgctxt "Polls"
+msgid "Show report"
+msgstr "レポートを表示"
+
+#: ../src/scenes/Forum.rb:3013 ../src/scenes/Messages.rb:638 ../src/scenes/Polls.rb:24 ../src/scenes/Polls.rb:121 ../src/scenes/Polls.rb:416
+msgctxt "Polls"
+msgid "Vote"
+msgstr "投票する"
+
+#: ../src/scenes/Forum.rb:3127
+msgctxt "Forum"
+msgid "Account archived"
+msgstr "アカウントがアーカイブされました"
+
+#: ../src/scenes/Forum.rb:3150
+msgctxt "Forum"
+msgid "Post type"
+msgstr "投稿タイプ"
+
+#: ../src/scenes/Forum.rb:3161
+msgctxt "Forum"
+msgid "Your reply"
+msgstr "あなたの返信"
+
+#: ../src/scenes/Forum.rb:3177
+msgctxt "Forum"
+msgid "Return"
+msgstr "戻る"
+
+#: ../src/scenes/Forum.rb:3189
+msgctxt "Forum"
+msgid "This post has been edited"
+msgstr "この投稿は編集されました"
+
+#: ../src/scenes/Forum.rb:3195
+msgctxt "Forum"
+msgid "%{count} user likes this post"
+msgid_plural "%{count} users like this post"
+msgstr[0] "%{count} 人がこの投稿を「いいね！」しました"
+
+#: ../src/scenes/Forum.rb:3230 ../src/scenes/Forum.rb:3255
+msgctxt "Forum"
+msgid "The post was created."
+msgstr "投稿が作成されました。"
+
+#: ../src/scenes/Forum.rb:3258
+msgctxt "Forum"
+msgid "Post creation failure."
+msgstr "投稿の作成に失敗しました。"
+
+#: ../src/scenes/Forum.rb:3268
+msgctxt "Forum"
+msgid "Received mention"
+msgstr "メンションを受け取りました"
+
+#: ../src/scenes/Forum.rb:3269
+msgctxt "Forum"
+msgid "Show mention"
+msgstr "メンションを表示"
+
+#: ../src/scenes/Forum.rb:3270
+msgctxt "Forum"
+msgid "Mention by %{user}"
+msgstr "%{user} からのメンション"
+
+#: ../src/scenes/Forum.rb:3272
+msgctxt "Forum"
+msgid "Send reply to mentioner"
+msgstr "メンションした人に返信を送る"
+
+#: ../src/scenes/Forum.rb:3282 ../src/scenes/Forum.rb:3283
+msgctxt "Forum"
+msgid "Reply"
+msgstr "返信"
+
+#: ../src/scenes/Forum.rb:3288
+msgctxt "Forum"
+msgid "Reply with quote"
+msgstr "引用して返信"
+
+#: ../src/scenes/Forum.rb:3300
+msgctxt "Forum"
+msgid "Like this post"
+msgstr "この投稿を「いいね！」する"
+
+#: ../src/scenes/Forum.rb:3301
+msgctxt "Forum"
+msgid "Dislike this post"
+msgstr "この投稿の「いいね！」を取り消す"
+
+#: ../src/scenes/Forum.rb:3311
+msgctxt "Forum"
+msgid "This post is now liked"
+msgstr "この投稿に「いいね！」しました"
+
+#: ../src/scenes/Forum.rb:3315
+msgctxt "forum"
+msgid "This post is no longer liked"
+msgstr "この投稿の「いいね！」を取り消しました"
+
+#: ../src/scenes/Forum.rb:3321
+msgctxt "Forum"
+msgid "Show post likes"
+msgstr "この投稿の「いいね！」を表示"
+
+#: ../src/scenes/Forum.rb:3330
+msgctxt "Forum"
+msgid "Users who like this post"
+msgstr "この投稿を「いいね！」したユーザー"
+
+#: ../src/scenes/Forum.rb:3342
+msgctxt "Forum"
+msgid "Show original post"
+msgstr "元の投稿を表示"
+
+#: ../src/scenes/Forum.rb:3345
+msgctxt "Forum"
+msgid "Original post"
+msgstr "元の投稿"
+
+#: ../src/scenes/Forum.rb:3350
+msgctxt "Forum"
+msgid "Report this post"
+msgstr "この投稿を報告する"
+
+#: ../src/scenes/Forum.rb:3356
+msgctxt "Forum"
+msgid "Navigation"
+msgstr "ナビゲーション"
+
+#: ../src/scenes/Forum.rb:3357 ../src/scenes/Forum.rb:3918
+msgctxt "Forum"
+msgid "Bookmarks"
+msgstr "ブックマーク"
+
+#: ../src/scenes/Forum.rb:3362
+msgctxt "Forum"
+msgid "Go to post"
+msgstr "投稿へ移動"
+
+#: ../src/scenes/Forum.rb:3367 ../src/scenes/Forum.rb:3393
+msgctxt "Forum"
+msgid "Select post"
+msgstr "投稿を選択"
+
+#: ../src/scenes/Forum.rb:3370
+msgctxt "Forum"
+msgid "Go to post number"
+msgstr "投稿番号へ移動"
+
+#: ../src/scenes/Forum.rb:3371
+msgctxt "Forum"
+msgid "Type post number"
+msgstr "投稿番号を入力"
+
+#: ../src/scenes/Forum.rb:3378
+msgctxt "Forum"
+msgid "Search in thread"
+msgstr "スレッド内を検索"
+
+#: ../src/scenes/Forum.rb:3379
+msgctxt "Forum"
+msgid "Enter a phrase to look for"
+msgstr "検索するフレーズを入力"
+
+#: ../src/scenes/Forum.rb:3397
+msgctxt "Forum"
+msgid "The entered phrase cannot be found."
+msgstr "入力されたフレーズは見つかりませんでした。"
+
+#: ../src/scenes/Forum.rb:3402
+msgctxt "Forum"
+msgid "Go to first post"
+msgstr "最初の投稿へ移動"
+
+#: ../src/scenes/Forum.rb:3406
+msgctxt "Forum"
+msgid "Go to last post"
+msgstr "最後の投稿へ移動"
+
+#: ../src/scenes/Forum.rb:3411
+msgctxt "Forum"
+msgid "Go to first new post"
+msgstr "最初の新しい投稿へ移動"
+
+#: ../src/scenes/Forum.rb:3418
+msgctxt "Forum"
+msgid "Mention post"
+msgstr "この投稿をメンション"
+
+#: ../src/scenes/Forum.rb:3424
+msgctxt "Forum"
+msgid "Listen to the thread"
+msgstr "スレッドを聞く"
+
+#: ../src/scenes/Forum.rb:3505
+msgctxt "Forum"
+msgid "Hide signatures"
+msgstr "署名を非表示"
+
+#: ../src/scenes/Forum.rb:3506
+msgctxt "Forum"
+msgid "Show signatures"
+msgstr "署名を表示"
+
+#: ../src/scenes/Forum.rb:3522
+msgctxt "Forum"
+msgid "Edit post"
+msgstr "投稿を編集"
+
+#: ../src/scenes/Forum.rb:3528
+msgctxt "Forum"
+msgid "Move post"
+msgstr "投稿を移動"
+
+#: ../src/scenes/Forum.rb:3556 ../src/scenes/Forum.rb:3734
+msgctxt "Forum"
+msgid "Post destination"
+msgstr "投稿の移動先"
+
+#: ../src/scenes/Forum.rb:3561
+msgctxt "Forum"
+msgid "The post has been moved."
+msgstr "投稿が移動されました。"
+
+#: ../src/scenes/Forum.rb:3567
+msgctxt "Forum"
+msgid "Lock post"
+msgstr "投稿をロック"
+
+#: ../src/scenes/Forum.rb:3568
+msgctxt "Forum"
+msgid "Unlock post"
+msgstr "投稿のロックを解除"
+
+#: ../src/scenes/Forum.rb:3579
+msgctxt "Forum"
+msgid "Post locked"
+msgstr "投稿がロックされました"
+
+#: ../src/scenes/Forum.rb:3581
+msgctxt "Forum"
+msgid "Post unlocked"
+msgstr "投稿のロックが解除されました"
+
+#: ../src/scenes/Forum.rb:3587
+msgctxt "Forum"
+msgid "Delete post"
+msgstr "投稿を削除"
+
+#: ../src/scenes/Forum.rb:3588 ../src/scenes/Forum.rb:3599
+msgctxt "Forum"
+msgid "Are you sure you want to delete this post?"
+msgstr "本当にこの投稿を削除しますか？"
+
+#: ../src/scenes/Forum.rb:3613
+msgctxt "Forum"
+msgid "Change post position"
+msgstr "投稿の位置を変更"
+
+#: ../src/scenes/Forum.rb:3619
+msgctxt "Forum"
+msgid "Place post above"
+msgstr "投稿を上に配置"
+
+#: ../src/scenes/Forum.rb:3622
+msgctxt "Forum"
+msgid "The post has been slided."
+msgstr "投稿が移動されました。"
+
+#: ../src/scenes/Forum.rb:3642
+msgctxt "Forum"
+msgid "Posts"
+msgstr "投稿"
+
+#: ../src/scenes/Forum.rb:3680
+msgctxt "Forum"
+msgid "No posts selected"
+msgstr "投稿が選択されていません"
+
+#: ../src/scenes/Forum.rb:3687
+msgctxt "Forum"
+msgid "%{count} post to move"
+msgid_plural "%{count} posts to move"
+msgstr[0] "%{count} 件の投稿を移動します"
+
+#: ../src/scenes/Forum.rb:3690
+msgctxt "Forum"
+msgid "%{count} post to delete"
+msgid_plural "%{count} posts to delete"
+msgstr[0] "%{count} 件の投稿を削除します"
+
+#: ../src/scenes/Forum.rb:3739
+msgctxt "Forum"
+msgid "The posts have been moved."
+msgstr "投稿が移動されました。"
+
+#: ../src/scenes/Forum.rb:3748
+msgctxt "Forum"
+msgid "The posts have been deleted."
+msgstr "投稿が削除されました。"
+
+#: ../src/scenes/Forum.rb:3768
+msgctxt "Forum"
+msgid "Nobody added you to their contact list."
+msgstr "誰もあなたを連絡先リストに追加していません。"
+
+#: ../src/scenes/Forum.rb:3772
+msgctxt "Forum"
+msgid "Users to mention: "
+msgstr "メンションするユーザー："
+
+#: ../src/scenes/Forum.rb:3773
+msgctxt "Forum"
+msgid "Message: "
+msgstr "メッセージ："
+
+#: ../src/scenes/Forum.rb:3774
+msgctxt "Forum"
+msgid "Mention"
+msgstr "メンション"
+
+#: ../src/scenes/Forum.rb:3775
+msgctxt "Forum"
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: ../src/scenes/Forum.rb:3796
+msgctxt "Forum"
+msgid "Error"
+msgstr "エラー"
+
+#: ../src/scenes/Forum.rb:3798
+msgctxt "Forum"
+msgid "The mention has been sent."
+msgstr "メンションが送信されました。"
+
+#: ../src/scenes/Forum.rb:3811
+msgctxt "Forum"
+msgid "Report comment"
+msgstr "コメントを報告"
+
+#: ../src/scenes/Forum.rb:3812
+msgctxt "Forum"
+msgid "Reported post"
+msgstr "報告された投稿"
+
+#: ../src/scenes/Forum.rb:3813
+msgctxt "Forum"
+msgid "Send post report"
+msgstr "投稿の報告を送信"
+
+#: ../src/scenes/Forum.rb:3824
+msgctxt "Forum"
+msgid "Post report has been sent."
+msgstr "投稿の報告が送信されました。"
+
+#: ../src/scenes/Forum.rb:3839
+msgctxt "Forum"
+msgid "edit your post here"
+msgstr "ここに投稿を編集"
+
+#: ../src/scenes/Forum.rb:3847
+msgctxt "Forum"
+msgid "Add attachment"
+msgstr "添付ファイルを追加"
+
+#: ../src/scenes/Forum.rb:3861
+msgctxt "Forum"
+msgid "Delete attachment"
+msgstr "添付ファイルを削除"
+
+#: ../src/scenes/Forum.rb:3888
+msgctxt "Forum"
+msgid "The post has been modified"
+msgstr "投稿が変更されました"
+
+#: ../src/scenes/Forum.rb:3918
+msgctxt "Forum"
+msgid "Post %{postnumber} by %{author}"
+msgstr "%{author} の投稿 %{postnumber}"
+
+#: ../src/scenes/Forum.rb:3921
+msgctxt "Forum"
+msgid "Delete bookmark"
+msgstr "ブックマークを削除"
+
+#: ../src/scenes/Forum.rb:3927
+msgctxt "Forum"
+msgid "New bookmark"
+msgstr "新しいブックマーク"
+
+#: ../src/scenes/Forum.rb:3960
+msgctxt "Forum"
+msgid "Bookmark deleted"
+msgstr "ブックマークが削除されました"
+
+#: ../src/scenes/Forum.rb:3969
+msgctxt "Forum"
+msgid "Bookmark description"
+msgstr "ブックマークの説明"
+
+#: ../src/scenes/Forum.rb:3972
+msgctxt "Forum"
+msgid "Bookmark created"
+msgstr "ブックマークが作成されました"
+
+#: ../src/scenes/Forum.rb:4349
+msgctxt "Forum"
+msgid "Category"
+msgstr "カテゴリー"
+
+#: ../src/scenes/Forum.rb:4355
+msgctxt "Forum"
+msgid "General"
+msgstr "一般"
+
+#: ../src/scenes/Forum.rb:4370
+msgctxt "Forum"
+msgid "Change group parent"
+msgstr "グループの親を変更"
+
+#: ../src/scenes/Forum.rb:4374 ../src/scenes/Forum.rb:4399
+msgctxt "Forum"
+msgid "None"
+msgstr "なし"
+
+#: ../src/scenes/Forum.rb:4374
+msgctxt "Forum"
+msgid "Select group parent"
+msgstr "グループの親を選択"
+
+#: ../src/scenes/Forum.rb:4382
+msgctxt "Forum"
+msgid "Prevent globally banned users from posting in this group"
+msgstr "全体的に禁止されたユーザーがこのグループに投稿するのを防ぐ"
+
+#: ../src/scenes/Forum.rb:4385
+msgctxt "Forum"
+msgid "Change group blog"
+msgstr "グループブログを変更"
+
+#: ../src/scenes/Forum.rb:4399
+msgctxt "Forum"
+msgid "Select blog"
+msgstr "ブログを選択"
+
+#: ../src/scenes/Forum.rb:4411
+msgctxt "Forum"
+msgid "Create group channel in conferences"
+msgstr "会議内にグループチャンネルを作成"
+
+#: ../src/scenes/Forum.rb:4427
+msgctxt "Forum"
+msgid "Regulations"
+msgstr "規約"
+
+#: ../src/scenes/Forum.rb:4431
+msgctxt "Forum"
+msgid "Permissions"
+msgstr "権限"
+
+#: ../src/scenes/Forum.rb:4432
+msgctxt "Forum"
+msgid "Prevent users from editing their posts"
+msgstr "ユーザーが自分の投稿を編集するのを防ぐ"
+
+#: ../src/scenes/Forum.rb:4433
+msgctxt "Forum"
+msgid "Prevent users from attaching polls"
+msgstr "ユーザーが投票を添付するのを防ぐ"
+
+#: ../src/scenes/Forum.rb:4434
+msgctxt "Forum"
+msgid "Prevent users from attaching files"
+msgstr "ユーザーがファイルを添付するのを防ぐ"
+
+#: ../src/scenes/Forum.rb:4435
+msgctxt "Forum"
+msgid "Hide information about edited posts"
+msgstr "編集された投稿の情報を隠す"
+
+#: ../src/scenes/Forum.rb:4436
+msgctxt "Forum"
+msgid "Hide edit history"
+msgstr "編集履歴を隠す"
+
+#: ../src/scenes/Forum.rb:4437
+msgctxt "Forum"
+msgid "Allow members to report posts"
+msgstr "メンバーが投稿を報告することを許可"
+
+#: ../src/scenes/Forum.rb:4438
+msgctxt "Forum"
+msgid "Disabled"
+msgstr "無効"
+
+#: ../src/scenes/Forum.rb:4438
+msgctxt "Forum"
+msgid "Show only to report author"
+msgstr "報告者のみに表示"
+
+#: ../src/scenes/Forum.rb:4438
+msgctxt "Forum"
+msgid "Show all accepted reports"
+msgstr "承認されたすべての報告を表示"
+
+#: ../src/scenes/Forum.rb:4438
+msgctxt "Forum"
+msgid "Show all reports"
+msgstr "すべての報告を表示"
+
+#: ../src/scenes/Forum.rb:4438
+msgctxt "Forum"
+msgid "Reports visibility"
+msgstr "報告の表示範囲"
+
+#: ../src/scenes/Forum.rb:4439
+msgctxt "Forum"
+msgid "Duration limit of audio posts in seconds, 0 for no limit"
+msgstr "音声投稿の秒数制限（0で制限なし）"
+
+#: ../src/scenes/Honors.rb:66
+msgctxt "Honors"
+msgid "A new badge"
+msgstr "新しいバッジ"
+
+#: ../src/scenes/Honors.rb:69
+msgctxt "Honors"
+msgid "Badges"
+msgstr "バッジ"
+
+#: ../src/scenes/Honors.rb:71
+msgctxt "Honors"
+msgid "Badges of %{user}"
+msgstr "%{user} のバッジ"
+
+#: ../src/scenes/Honors.rb:74
+msgctxt "Honors"
+msgid "The user has been given no badges."
+msgstr "このユーザーにはバッジが与えられていません。"
+
+#: ../src/scenes/Honors.rb:107 ../src/scenes/Honors.rb:122 ../src/scenes/Honors.rb:219
+msgctxt "Honors"
+msgid "Level"
+msgstr "レベル"
+
+#: ../src/scenes/Honors.rb:135
+msgctxt "Honors"
+msgid "Set as main honor"
+msgstr "メインの称号に設定"
+
+#: ../src/scenes/Honors.rb:140
+msgctxt "Honors"
+msgid "The badge has been set as default."
+msgstr "バッジがデフォルトに設定されました。"
+
+#: ../src/scenes/Honors.rb:144
+msgctxt "Honors"
+msgid "Grant a badge"
+msgstr "バッジを授与"
+
+#: ../src/scenes/Honors.rb:145
+msgctxt "Honors"
+msgid "Who should be granted this badge?"
+msgstr "このバッジを誰に授与しますか？"
+
+#: ../src/scenes/Honors.rb:151
+msgctxt "Honors"
+msgid "The badge has been granted"
+msgstr "バッジが授与されました"
+
+#: ../src/scenes/Honors.rb:155
+msgctxt "Honors"
+msgid "Edit challenges"
+msgstr "チャレンジを編集"
+
+#: ../src/scenes/Honors.rb:161
+msgctxt "Honors"
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/scenes/Honors.rb:162
+msgctxt "Honors"
+msgid "Are you sure you want to delete this badge? All users granted with this badge will loose it."
+msgstr "本当にこのバッジを削除しますか？このバッジを授与されたすべてのユーザーが失います。"
+
+#: ../src/scenes/Honors.rb:167
+msgctxt "Honors"
+msgid "Honor deleted"
+msgstr "称号が削除されました"
+
+#: ../src/scenes/Honors.rb:185 ../src/scenes/Honors.rb:198 ../src/scenes/Honors.rb:237
+msgctxt "Honors"
+msgid "Add challenge"
+msgstr "チャレンジを追加"
+
+#: ../src/scenes/Honors.rb:186
+msgctxt "Honors"
+msgid "Challenges"
+msgstr "チャレンジ"
+
+#: ../src/scenes/Honors.rb:220
+msgctxt "Honors"
+msgid "English level"
+msgstr "英語レベル"
+
+#: ../src/scenes/Honors.rb:262
+msgctxt "Honors"
+msgid "level"
+msgstr "レベル"
+
+#: ../src/scenes/Honors.rb:303
+msgctxt "Honors"
+msgid "Badge name"
+msgstr "バッジ名"
+
+#: ../src/scenes/Honors.rb:303
+msgctxt "Honors"
+msgid "Badge description"
+msgstr "バッジの説明"
+
+#: ../src/scenes/Honors.rb:303
+msgctxt "Honors"
+msgid "Badge name in English"
+msgstr "バッジ名（英語）"
+
+#: ../src/scenes/Honors.rb:303
+msgctxt "Honors"
+msgid "Badge description in English"
+msgstr "バッジの説明（英語）"
+
+#: ../src/scenes/Honors.rb:303
+msgctxt "Honors"
+msgid "Add"
+msgstr "追加"
+
+#: ../src/scenes/Honors.rb:317
+msgctxt "Honors"
+msgid "The badge has been added"
+msgstr "バッジが追加されました"
+
+#: ../src/scenes/Install.rb:3
+msgctxt "Install"
+msgid "Download and install the newest version"
+msgstr "最新バージョンをダウンロードしてインストール"
+
+#: ../src/scenes/Install.rb:3
+msgctxt "Install"
+msgid "Install current version"
+msgstr "現在のバージョンをインストール"
+
+#: ../src/scenes/Install.rb:3
+msgctxt "Install"
+msgid "Which version would you like to use?"
+msgstr "どのバージョンを使用しますか？"
+
+#: ../src/scenes/Loading.rb:262
+msgctxt "Loading"
+msgid "Elten detected that you are using NVDA. To support some features of this screenreader, it is necessary to install Elten addon. Do you want to do it now?"
+msgstr "エルテンはNVDAを使用していることを検出しました。このスクリーンリーダーの一部の機能をサポートするために、Eltenアドオンをインストールする必要があります。今すぐインストールしますか？"
+
+#: ../src/scenes/Loading.rb:264
+msgctxt "Loading"
+msgid "New version of NVDA Elten addon is available. The version you're using is no longer supported in this Elten release and may cause some errors. Do you want to update it now?"
+msgstr "NVDA用エルテンアドオンの新しいバージョンが利用可能です。現在使用しているバージョンはこのEltenリリースではサポートされておらず、エラーが発生する可能性があります。今すぐ更新しますか？"
+
+#: ../src/scenes/Loading.rb:303
+msgctxt "Loading"
+msgid ""
+"Warning! Elten failed to verify server encryption key. It is possible that you are not connecting to Elten server but to one prepared by hackers. It is also possible that Elten Server key has changed. Any details should be provided on Elten Website Forum. If no "
+"information about key change was provided, it is very likely that you are vulnerable to hacker attack. In this cause any data that you will provide, including password, can be stolen. Are you sure you want to proceed with this connection? Select No to exit Elten."
+msgstr ""
+"警告！エルテンはサーバーの暗号化キーを検証できませんでした。あなたはEltenサーバーではなく、ハッカーによって準備されたサーバーに接続している可能性があります。また、Eltenサーバーキーが変更された可能性もあります。詳細はEltenウェブサイトのフォーラムで提供されるべきで"
+"す。キーの変更に関する情報が提供されていない場合、ハッカー攻撃に対して脆弱である可能性が高いです。この場合、パスワードを含むあなたが提供するすべてのデータが盗まれる可能性があります。この接続を続行してもよろしいですか？「いいえ」を選択するとEltenを終了します。"
+
+#: ../src/scenes/Loading.rb:320
+msgctxt "Loading"
+msgid "A new version of the program is available."
+msgstr "新しいバージョンのプログラムが利用可能です。"
+
+#: ../src/scenes/Loading.rb:352
+msgctxt "Loading"
+msgid ""
+"Attention!\n"
+"Since the release of version 2.5.2.1, new restrictions have been introduced for globally banned users.\n"
+"By default, they are prevented from speaking in any groups and writing to other people.\n"
+"\n"
+"To allow banned people to speak in a group, change this option from the group's settings, General tab.\n"
+"Similarly, to allow these users to write private messages to you, you must allow this from within your account settings, Privacy tab.\n"
+"\n"
+"Also, all groups moderated by banned users have been removed from most public lists.\n"
+"\n"
+"At the same time, three changes have since been made to the premium packages at the request of users:\n"
+"First of all, premium features are now visible in menus.\n"
+"It has also been made possible to buy premium packages for a period of one month.\n"
+"Other billing currencies have also been added."
+msgstr ""
+"注意！\n"
+"バージョン２.５.２.１のリリース以降、グローバルに禁止されたユーザーに対する新しい制限が導入されました。\n"
+"デフォルトでは、彼らはどのグループでも発言したり、他の人に書き込むことができません。\n"
+"\n"
+"禁止された人々がグループで発言できるようにするには、グループの設定の「一般」タブからこのオプションを変更してください。\n"
+"同様に、これらのユーザーがあなたにプライベートメッセージを書き込むことを許可するには、アカウント設定の「プライバシー」タブから許可する必要があります。\n"
+"\n"
+"また、禁止されたユーザーが管理するすべてのグループがほとんどの公開リストから削除されました。\n"
+"\n"
+"同時に、ユーザーの要望によりプレミアムパッケージに3つの変更が加えられました：\n"
+"まず、プレミアム機能がメニューに表示されるようになりました。\n"
+"また、1か月間のプレミアムパッケージを購入できるようになりました。\n"
+"他の請求通貨も追加されました。"
+
+#: ../src/scenes/Loading.rb:366
+msgctxt "Loading"
+msgid "Information about important changes"
+msgstr "重要な変更に関する情報"
+
+#: ../src/scenes/Loading.rb:383
+msgctxt "Loading"
+msgid "Log in"
+msgstr "ログイン"
+
+#: ../src/scenes/Loading.rb:383
+msgctxt "Loading"
+msgid "Reinstall"
+msgstr "再インストール"
+
+#: ../src/scenes/Loading.rb:383
+msgctxt "Loading"
+msgid "Settings"
+msgstr "設定"
+
+#: ../src/scenes/Loading.rb:383
+msgctxt "Loading"
+msgid "Password reset"
+msgstr "パスワードリセット"
+
+#: ../src/scenes/Loading.rb:383
+msgctxt "Loading"
+msgid "Register"
+msgstr "登録"
+
+#: ../src/scenes/Loading.rb:383
+msgctxt "Loading"
+msgid "Use guest account"
+msgstr "ゲストアカウントを使用"
+
+#: ../src/scenes/Log.rb:10
+msgctxt "Log"
+msgid "Log level"
+msgstr "ログレベル"
+
+#: ../src/scenes/Log.rb:11
+msgctxt "Log"
+msgid "Show event level"
+msgstr "イベントレベルを表示"
+
+#: ../src/scenes/Log.rb:12
+msgctxt "Log"
+msgid "Show event time"
+msgstr "イベント時間を表示"
+
+#: ../src/scenes/Log.rb:13
+msgctxt "Log"
+msgid "Log"
+msgstr "ログ"
+
+#: ../src/scenes/Login.rb:23
+msgctxt "Login"
+msgid "Username:"
+msgstr "ユーザー名："
+
+#: ../src/scenes/Login.rb:31 ../src/scenes/Login.rb:158
+msgctxt "Login"
+msgid "Password:"
+msgstr "パスワード："
+
+#: ../src/scenes/Login.rb:44 ../src/scenes/Login.rb:245
+msgctxt "Login"
+msgid "Enter pin code"
+msgstr "PINコードを入力"
+
+#: ../src/scenes/Login.rb:60 ../src/scenes/Login.rb:169
+msgctxt "Login"
+msgid ""
+"Do you want to enable auto-Login-key encryption? When encrypted, the Auto-Login Key will be readable only on this computer, and its copying or exporting will not allow other devices to access your account. Note: If you encrypt your Auto-Login Key, the created "
+"portable versions will not be able to automatically log into your account from other devices, even if you copy your settings, and you will be prompted to enter your password. You can create as many auto-login-keys as you wish for all other computers you are using."
+msgstr ""
+"自動ログインキーの暗号化を有効にしますか？暗号化すると、自動ログインキーはこのコンピュータでのみ読み取ることができ、コピーやエクスポートしても他のデバイスからあなたのアカウントにアクセスすることはできません。注意：自動ログインキーを暗号化すると、設定をコピーしても"
+"作成されたポータブルバージョンは他のデバイスから自動的にアカウントにログインすることはできず、パスワードの入力を求められます。使用しているすべてのコンピュータ用に必要なだけの自動ログインキーを作成できます。"
+
+#: ../src/scenes/Login.rb:88
+msgctxt "Login"
+msgid "Two-factor authentication is enabled on this account. Select method to authenticate."
+msgstr "このアカウントでは二要素認証が有効になっています。認証方法を選択してください。"
+
+#: ../src/scenes/Login.rb:88
+msgctxt "Login"
+msgid "Authenticate using backup code"
+msgstr "バックアップコードを使用して認証"
+
+#: ../src/scenes/Login.rb:88
+msgctxt "Login"
+msgid "Authenticate using SMS"
+msgstr "SMSを使用して認証"
+
+#: ../src/scenes/Login.rb:104
+msgctxt "Login"
+msgid "Enter the code sent to you  by text message to allow this device to login. If you do not have access to the  phone number used, select the password reset option to disable two-factor  authentication."
+msgstr "このデバイスでログインできるように、テキストメッセージで送信されたコードを入力してください。使用した電話番号にアクセスできない場合は、パスワードリセットオプションを選択して二要素認証を無効にしてください。"
+
+#: ../src/scenes/Login.rb:106
+msgctxt "Login"
+msgid "Enter backup code"
+msgstr "バックアップコードを入力"
+
+#: ../src/scenes/Login.rb:119
+msgctxt "Login"
+msgid "Verification failed."
+msgstr "認証に失敗しました。"
+
+#: ../src/scenes/Login.rb:124
+msgctxt "Login"
+msgid "The entered code is wrong, please try again"
+msgstr "入力したコードが間違っています。もう一度お試しください。"
+
+#: ../src/scenes/Login.rb:146
+msgctxt "Login"
+msgid "Do you want to enable auto log in for account %{user}?"
+msgstr "アカウント %{user} に対して自動ログインを有効にしますか？"
+
+#: ../src/scenes/Login.rb:146
+msgctxt "Login"
+msgid "Do not ask again"
+msgstr "今後表示しない"
+
+#: ../src/scenes/Login.rb:148
+msgctxt "Login"
+msgid ""
+"The saved login data uses the old account authentication method in which  susceptibility to hacker attacks has been detected. New, safer automatic login  algorithms have been introduced in Elten 2.2. It is recommended that you convert  the saved information into a "
+"new system in order to improve the security of your  account. Do you want to update the saved information now?"
+msgstr ""
+"保存されたログインデータは、ハッカー攻撃に対する脆弱性が検出された古いアカウント認証方法を使用しています。Elten 2.2では、新しいより安全な自動ログインアルゴリズムが導入されました。アカウントのセキュリティを向上させるために、保存された情報を新しいシステムに変換するこ"
+"とをお勧めします。今すぐ保存された情報を更新しますか？"
+
+#: ../src/scenes/Login.rb:164
+msgctxt "Login"
+msgid "An error occurred while authenticating the identity. You might have provided an  incorrect password."
+msgstr "本人確認の認証中にエラーが発生しました。不正なパスワードを入力した可能性があります。"
+
+#: ../src/scenes/Login.rb:179
+msgctxt "Login"
+msgid "Automatic login will be proceeding until you log out.Automatic login keys can be  managed from the My Account tab in the Community menu."
+msgstr "ログアウトするまで自動ログインが続行されます。自動ログインキーはコミュニティメニューの「マイアカウント」タブから管理できます。"
+
+#: ../src/scenes/Login.rb:181
+msgctxt "Login"
+msgid "Login data has been updated. Automatic login will be proceeding until you log  out. Automatic login keys can be managed from the My Account tab in the Community  menu."
+msgstr "ログインデータが更新されました。ログアウトするまで自動ログインが続行されます。自動ログインキーはコミュニティメニューの「マイアカウント」タブから管理できます。"
+
+#: ../src/scenes/Login.rb:192
+msgctxt "Login"
+msgid "To reenable auto log in feature, proceed to the general settings."
+msgstr "自動ログイン機能を再度有効にするには、一般設定に進んでください。"
+
+#: ../src/scenes/Login.rb:206
+msgctxt "Login"
+msgid "Logged in as: %{user}"
+msgstr "%{user} としてログインしました"
+
+#: ../src/scenes/Login.rb:218
+msgctxt "Login"
+msgid "Invalid login or password."
+msgstr "ログイン名またはパスワードが無効です。"
+
+#: ../src/scenes/Login.rb:224
+msgctxt "Login"
+msgid "Login failure."
+msgstr "ログインに失敗しました。"
+
+#: ../src/scenes/Login.rb:230
+msgctxt "Login"
+msgid "Connection failure."
+msgstr "接続に失敗しました。"
+
+#: ../src/scenes/Login.rb:242
+msgctxt "Login"
+msgid "Do you want to encrypt this key with a custom pin code? You will be prompted for this code everytime you start Elten to unlock your account, but it will not be saved on the server and will be valid only for the auto-login-key stored on this device."
+msgstr "このキーをカスタムPINコードで暗号化しますか？Eltenを起動するたびにこのコードを入力してアカウントのロックを解除する必要がありますが、このコードはサーバーに保存されず、このデバイスに保存された自動ログインキーにのみ有効です。"
+
+#: ../src/scenes/Login.rb:247
+msgctxt "Login"
+msgid "Enter pin code again"
+msgstr "もう一度PINコードを入力"
+
+#: ../src/scenes/Login.rb:252
+msgctxt "Login"
+msgid "The pin codes entered are different, please try again."
+msgstr "入力したPINコードが異なります。もう一度お試しください。"
+
+#: ../src/scenes/Main.rb:45
+msgctxt "Main"
+msgid "A new beta version of the program is available."
+msgstr "プログラムの新しいベータバージョンが利用可能です。"
+
+#: ../src/scenes/Main.rb:168
+msgctxt "Main"
+msgid "Quick actions"
+msgstr "クイックアクション"
+
+#: ../src/scenes/Main.rb:169
+msgctxt "Main"
+msgid "Use Shift with up/down arrows to move quick actions"
+msgstr "シフトキーと上下矢印キーを使用してクイックアクションを移動"
+
+#: ../src/scenes/Main.rb:184
+msgctxt "Main"
+msgid "Rename"
+msgstr "名前を変更"
+
+#: ../src/scenes/Main.rb:185
+msgctxt "Main"
+msgid "Action label"
+msgstr "アクションラベル"
+
+#: ../src/scenes/Main.rb:192
+msgctxt "Main"
+msgid "Change hotkey"
+msgstr "ホットキーを変更"
+
+#: ../src/scenes/Main.rb:193
+msgctxt "Main"
+msgid "None"
+msgstr "なし"
+
+#: ../src/scenes/Main.rb:206
+msgctxt "Main"
+msgid "Hotkey for action %{label}"
+msgstr "アクション %{label} のホットキー"
+
+#: ../src/scenes/Main.rb:220
+msgctxt "Main"
+msgid "This hotkey is already used by action %{action}"
+msgstr "このホットキーは既にアクション %{action} で使用されています"
+
+#: ../src/scenes/Main.rb:227
+msgctxt "Main"
+msgid "Move up"
+msgstr "上に移動"
+
+#: ../src/scenes/Main.rb:232
+msgctxt "Main"
+msgid "Move down"
+msgstr "下に移動"
+
+#: ../src/scenes/Main.rb:236 ../src/scenes/Main.rb:247
+msgctxt "Main"
+msgid "Hide this action"
+msgstr "このアクションを非表示"
+
+#: ../src/scenes/Main.rb:237
+msgctxt "Main"
+msgid "Show this action"
+msgstr "このアクションを表示"
+
+#: ../src/scenes/Main.rb:242 ../src/scenes/Main.rb:247
+msgctxt "Main"
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/scenes/Main.rb:245
+msgctxt "Main"
+msgid "Are you sure you want to delete this quick action?"
+msgstr "本当にこのクイックアクションを削除しますか？"
+
+#: ../src/scenes/Main.rb:247
+msgctxt "Main"
+msgid "If you delete this action, you will also delete the keyboard shortcut assigned to it. If you want to keep the keyboard shortcut, you can hide this action. You can show or remove hidden actions at any time."
+msgstr "このアクションを削除すると、それに割り当てられたキーボードショートカットも削除されます。キーボードショートカットを保持したい場合は、このアクションを非表示にできます。非表示のアクションはいつでも表示または削除できます。"
+
+#: ../src/scenes/Main.rb:259
+msgctxt "Main"
+msgid "Show hidden actions"
+msgstr "非表示のアクションを表示"
+
+#: ../src/scenes/Main.rb:260
+msgctxt "Main"
+msgid "Hide hidden actions"
+msgstr "非表示のアクションを隠す"
+
+#: ../src/scenes/Main.rb:265
+msgctxt "Main"
+msgid "Add"
+msgstr "追加"
+
+#: ../src/scenes/Main.rb:268
+msgctxt "Main"
+msgid "Restore defaults"
+msgstr "デフォルトに戻す"
+
+#: ../src/scenes/Main.rb:269
+msgctxt "Main"
+msgid "Are you sure you want to restore default Quick Actions?"
+msgstr "本当にクイックアクションをデフォルトに戻しますか？"
+
+#: ../src/scenes/Main.rb:290
+msgctxt "Main"
+msgid "Select quick action to add"
+msgstr "追加するクイックアクションを選択"
+
+#: ../src/scenes/Main.rb:318
+msgctxt "Main"
+msgid "%{count} user likes it"
+msgid_plural "%{count} users like it"
+msgstr[0] "%{count} 人が「いいね！」しました"
+
+#: ../src/scenes/Main.rb:326
+msgctxt "Main"
+msgid "Feed"
+msgstr "フィード"
+
+#: ../src/scenes/Main.rb:347
+msgctxt "Main"
+msgid "Show responses"
+msgstr "返信を表示"
+
+#: ../src/scenes/Main.rb:351
+msgctxt "Main"
+msgid "Show conversation"
+msgstr "会話を表示"
+
+#: ../src/scenes/Main.rb:356
+msgctxt "Main"
+msgid "Show likes"
+msgstr "「いいね！」を表示"
+
+#: ../src/scenes/Main.rb:362
+msgctxt "Main"
+msgid "Users who like this post"
+msgstr "この投稿を「いいね！」したユーザー"
+
+#: ../src/scenes/Main.rb:389
+msgctxt "Main"
+msgid "Like this message"
+msgstr "このメッセージを「いいね！」する"
+
+#: ../src/scenes/Main.rb:390
+msgctxt "Main"
+msgid "Dislike this message"
+msgstr "このメッセージの「いいね！」を取り消す"
+
+#: ../src/scenes/Main.rb:395
+msgctxt "Main"
+msgid "Message liked"
+msgstr "メッセージに「いいね！」しました"
+
+#: ../src/scenes/Main.rb:395
+msgctxt "Main"
+msgid "Message disliked"
+msgstr "メッセージの「いいね！」を取り消しました"
+
+#: ../src/scenes/Main.rb:402
+msgctxt "Main"
+msgid "Are you sure you want to delete this post?"
+msgstr "本当にこの投稿を削除しますか？"
+
+#: ../src/scenes/Messages.rb:134 ../src/scenes/Messages.rb:438
+msgctxt "Messages"
+msgid "Last message"
+msgstr "最新のメッセージ"
+
+#: ../src/scenes/Messages.rb:135 ../src/scenes/Messages.rb:439 ../src/scenes/Messages.rb:589
+msgctxt "Messages"
+msgid "New"
+msgstr "新規"
+
+#: ../src/scenes/Messages.rb:138 ../src/scenes/Messages.rb:442 ../src/scenes/Messages.rb:592
+msgctxt "Messages"
+msgid "Show older"
+msgstr "以前のメッセージを表示"
+
+#: ../src/scenes/Messages.rb:169
+msgctxt "Messages"
+msgid "Show all messages"
+msgstr "すべてのメッセージを表示"
+
+#: ../src/scenes/Messages.rb:174
+msgctxt "Messages"
+msgid "Show subjects"
+msgstr "件名を表示"
+
+#: ../src/scenes/Messages.rb:179
+msgctxt "Messages"
+msgid "Mark all messages in this conversation as read"
+msgstr "この会話のすべてのメッセージを既読にする"
+
+#: ../src/scenes/Messages.rb:185
+msgctxt "Messages"
+msgid "All messages in this conversation have been marked as read."
+msgstr "この会話のすべてのメッセージが既読になりました。"
+
+#: ../src/scenes/Messages.rb:193
+msgctxt "Messages"
+msgid "Add conversation to quick actions"
+msgstr "会話をクイックアクションに追加"
+
+#: ../src/scenes/Messages.rb:194
+msgctxt "Messages"
+msgid "Add list of conversations to quick actions"
+msgstr "会話リストをクイックアクションに追加"
+
+#: ../src/scenes/Messages.rb:195 ../src/scenes/Messages.rb:445
+msgctxt "Messages"
+msgid "Conversations with %{user}"
+msgstr "%{user} との会話"
+
+#: ../src/scenes/Messages.rb:196
+msgctxt "Messages"
+msgid "Conversations added to quick actions"
+msgstr "会話がクイックアクションに追加されました"
+
+#: ../src/scenes/Messages.rb:198
+msgctxt "Messages"
+msgid "Add all messages in this conversation to quick actions"
+msgstr "この会話のすべてのメッセージをクイックアクションに追加"
+
+#: ../src/scenes/Messages.rb:199
+msgctxt "Messages"
+msgid "Messages with %{user}"
+msgstr "%{user} とのメッセージ"
+
+#: ../src/scenes/Messages.rb:200
+msgctxt "Messages"
+msgid "Conversation added to quick actions"
+msgstr "会話がクイックアクションに追加されました"
+
+#: ../src/scenes/Messages.rb:204
+msgctxt "Messages"
+msgid "Mute this conversation"
+msgstr "この会話をミュート"
+
+#: ../src/scenes/Messages.rb:205
+msgctxt "Messages"
+msgid "Mute for a week"
+msgstr "1週間ミュート"
+
+#: ../src/scenes/Messages.rb:205
+msgctxt "Messages"
+msgid "Mute until manually unmuted"
+msgstr "手動でミュート解除するまでミュート"
+
+#: ../src/scenes/Messages.rb:205
+msgctxt "Messages"
+msgid "Mute for a quarter"
+msgstr "四半期ミュート"
+
+#: ../src/scenes/Messages.rb:205
+msgctxt "Messages"
+msgid "Mute for an hour"
+msgstr "1時間ミュート"
+
+#: ../src/scenes/Messages.rb:205
+msgctxt "Messages"
+msgid "Mute for a day"
+msgstr "1日ミュート"
+
+#: ../src/scenes/Messages.rb:213
+msgctxt "Messages"
+msgid "Unmute this conversation"
+msgstr "この会話のミュートを解除"
+
+#: ../src/scenes/Messages.rb:218
+msgctxt "Messages"
+msgid "Edit conversation"
+msgstr "会話を編集"
+
+#: ../src/scenes/Messages.rb:222
+msgctxt "Messages"
+msgid "Leave"
+msgstr "退出"
+
+#: ../src/scenes/Messages.rb:223
+msgctxt "Messages"
+msgid "Are you sure you want to leave this group?"
+msgstr "本当にこのグループを退出しますか？"
+
+#: ../src/scenes/Messages.rb:230
+msgctxt "Messages"
+msgid "Delete conversations"
+msgstr "会話を削除"
+
+#: ../src/scenes/Messages.rb:235
+msgctxt "Messages"
+msgid "Set all messages as a default view"
+msgstr "すべてのメッセージをデフォルトビューに設定"
+
+#: ../src/scenes/Messages.rb:236
+msgctxt "Messages"
+msgid "Set subjects as a default view"
+msgstr "件名をデフォルトビューに設定"
+
+#: ../src/scenes/Messages.rb:241
+msgctxt "Messages"
+msgid "Create new conversation"
+msgstr "新しい会話を作成"
+
+#: ../src/scenes/Messages.rb:248
+msgctxt "Messages"
+msgid "Mark all messages as read"
+msgstr "すべてのメッセージを既読にする"
+
+#: ../src/scenes/Messages.rb:249
+msgctxt "messages"
+msgid "Are you sure you want to mark all messages in all conversations as read?"
+msgstr "本当にすべての会話のすべてのメッセージを既読にしますか？"
+
+#: ../src/scenes/Messages.rb:255
+msgctxt "Messages"
+msgid "All messages have been marked as read."
+msgstr "すべてのメッセージが既読になりました。"
+
+#: ../src/scenes/Messages.rb:264
+msgctxt "Messages"
+msgid "Search"
+msgstr "検索"
+
+#: ../src/scenes/Messages.rb:268
+msgctxt "Messages"
+msgid "Show flagged messages"
+msgstr "フラグ付きメッセージを表示"
+
+#: ../src/scenes/Messages.rb:287
+msgctxt "Messages"
+msgid "Conversation name"
+msgstr "会話名"
+
+#: ../src/scenes/Messages.rb:288
+msgctxt "Messages"
+msgid "Conversation members"
+msgstr "会話のメンバー"
+
+#: ../src/scenes/Messages.rb:289
+msgctxt "Messages"
+msgid "Create"
+msgstr "作成"
+
+#: ../src/scenes/Messages.rb:293
+msgctxt "messages"
+msgid "Modify"
+msgstr "変更"
+
+#: ../src/scenes/Messages.rb:298
+msgctxt "Messages"
+msgid "Add user"
+msgstr "ユーザーを追加"
+
+#: ../src/scenes/Messages.rb:299
+msgctxt "Messages"
+msgid "User to add"
+msgstr "追加するユーザー"
+
+#: ../src/scenes/Messages.rb:308
+msgctxt "Messages"
+msgid "Delete user from conversation"
+msgstr "会話からユーザーを削除"
+
+#: ../src/scenes/Messages.rb:340
+msgctxt "Messages"
+msgid "Conversation has been created"
+msgstr "会話が作成されました"
+
+#: ../src/scenes/Messages.rb:342
+msgctxt "Messages"
+msgid "Conversation has been modified"
+msgstr "会話が変更されました"
+
+#: ../src/scenes/Messages.rb:378
+msgctxt "Messages"
+msgid "Are you sure you want to delete all messages with user %{user}"
+msgstr "本当にユーザー %{user} とのすべてのメッセージを削除しますか？"
+
+#: ../src/scenes/Messages.rb:383
+msgctxt "Messages"
+msgid "All conversations with user have been deleted."
+msgstr "ユーザーとのすべての会話が削除されました。"
+
+#: ../src/scenes/Messages.rb:409
+msgctxt "Messages"
+msgid "There are no new messages"
+msgstr "新しいメッセージはありません"
+
+#: ../src/scenes/Messages.rb:438 ../src/scenes/Messages.rb:801
+msgctxt "Messages"
+msgid "From"
+msgstr "差出人"
+
+#: ../src/scenes/Messages.rb:438
+msgctxt "Messages"
+msgid "No subject"
+msgstr "件名なし"
+
+#: ../src/scenes/Messages.rb:474
+msgctxt "Messages"
+msgid "Reply in thread"
+msgstr "スレッドに返信"
+
+#: ../src/scenes/Messages.rb:477
+msgctxt "Messages"
+msgid "Delete conversation"
+msgstr "会話を削除"
+
+#: ../src/scenes/Messages.rb:482 ../src/scenes/Messages.rb:782
+msgctxt "Messages"
+msgid "Send a new message in this conversation"
+msgstr "この会話に新しいメッセージを送信"
+
+#: ../src/scenes/Messages.rb:493
+msgctxt "Messages"
+msgid "Are you sure you want to delete conversation %{conversationname} with user %{user}"
+msgstr "本当にユーザー %{user} との会話 %{conversationname} を削除しますか？"
+
+#: ../src/scenes/Messages.rb:498
+msgctxt "Messages"
+msgid "The conversation has been deleted."
+msgstr "会話が削除されました。"
+
+#: ../src/scenes/Messages.rb:513
+msgctxt "Messages"
+msgid "Enter a phrase to look for"
+msgstr "検索するフレーズを入力"
+
+#: ../src/scenes/Messages.rb:588
+msgctxt "Messages"
+msgid "Open this message to read more"
+msgstr "詳細を読むにはこのメッセージを開いてください"
+
+#: ../src/scenes/Messages.rb:596
+msgctxt "Messages"
+msgid "Messages in conversation %{subject} with %{user}"
+msgstr "%{user} との会話 %{subject} 内のメッセージ"
+
+#: ../src/scenes/Messages.rb:597
+msgctxt "Messages"
+msgid "Flagged messages"
+msgstr "フラグ付きメッセージ"
+
+#: ../src/scenes/Messages.rb:598
+msgctxt "Messages"
+msgid "Found items"
+msgstr "見つかった項目"
+
+#: ../src/scenes/Messages.rb:601
+msgctxt "Messages"
+msgid "Compose"
+msgstr "作成"
+
+#: ../src/scenes/Messages.rb:601
+msgctxt "Messages"
+msgid "Your reply"
+msgstr "あなたの返信"
+
+#: ../src/scenes/Messages.rb:617 ../src/scenes/Messages.rb:1003
+msgctxt "Messages"
+msgid "Are you sure you want to cancel creating this message?"
+msgstr "このメッセージの作成をキャンセルしてもよろしいですか？"
+
+#: ../src/scenes/Messages.rb:668 ../src/scenes/Messages.rb:869
+msgctxt "Messages"
+msgid "Attachments"
+msgstr "添付ファイル"
+
+#: ../src/scenes/Messages.rb:674 ../src/scenes/Messages.rb:870
+msgctxt "Messages"
+msgid "Polls"
+msgstr "投票"
+
+#: ../src/scenes/Messages.rb:709 ../src/scenes/Messages.rb:1053
+msgctxt "Messages"
+msgid "Message has been sent"
+msgstr "メッセージが送信されました"
+
+#: ../src/scenes/Messages.rb:724
+msgctxt "Messages"
+msgid "Reply to message sender"
+msgstr "メッセージの送信者に返信"
+
+#: ../src/scenes/Messages.rb:731
+msgctxt "Messages"
+msgid "Flag"
+msgstr "フラグ"
+
+#: ../src/scenes/Messages.rb:732
+msgctxt "Messages"
+msgid "Remove flag"
+msgstr "フラグを削除"
+
+#: ../src/scenes/Messages.rb:738
+msgctxt "Messages"
+msgid "This message has been flagged."
+msgstr "このメッセージにフラグが立てられました。"
+
+#: ../src/scenes/Messages.rb:745
+msgctxt "Messages"
+msgid "This message is no longer flagged."
+msgstr "このメッセージのフラグが削除されました。"
+
+#: ../src/scenes/Messages.rb:753
+msgctxt "Messages"
+msgid "Protect"
+msgstr "保護"
+
+#: ../src/scenes/Messages.rb:754
+msgctxt "Messages"
+msgid "Unprotect"
+msgstr "保護を解除"
+
+#: ../src/scenes/Messages.rb:761
+msgctxt "Messages"
+msgid "This message has been protected."
+msgstr "このメッセージは保護されています。"
+
+#: ../src/scenes/Messages.rb:768
+msgctxt "Messages"
+msgid "This message is no longer protected."
+msgstr "このメッセージの保護が解除されました。"
+
+#: ../src/scenes/Messages.rb:787
+msgctxt "Messages"
+msgid "Forward"
+msgstr "転送"
+
+#: ../src/scenes/Messages.rb:815
+msgctxt "Messages"
+msgid "Are you sure you want to delete this message?"
+msgstr "本当にこのメッセージを削除しますか？"
+
+#: ../src/scenes/Messages.rb:820
+msgctxt "Messages"
+msgid "The message has been deleted."
+msgstr "メッセージが削除されました。"
+
+#: ../src/scenes/Messages.rb:867
+msgctxt "Messages"
+msgid "Audio message"
+msgstr "音声メッセージ"
+
+#: ../src/scenes/Messages.rb:875
+msgctxt "Messages"
+msgid "Attach a file"
+msgstr "ファイルを添付"
+
+#: ../src/scenes/Messages.rb:876
+msgctxt "Messages"
+msgid "Select a file to attach"
+msgstr "添付するファイルを選択"
+
+#: ../src/scenes/Messages.rb:882
+msgctxt "Messages"
+msgid "The file is too large."
+msgstr "ファイルが大きすぎます。"
+
+#: ../src/scenes/Messages.rb:886
+msgctxt "Messages"
+msgid "File attached."
+msgstr "ファイルが添付されました。"
+
+#: ../src/scenes/Messages.rb:894
+msgctxt "Messages"
+msgid "Delete attachment"
+msgstr "添付ファイルを削除"
+
+#: ../src/scenes/Messages.rb:905
+msgctxt "Messages"
+msgid "Attach a poll"
+msgstr "投票を添付"
+
+#: ../src/scenes/Messages.rb:918
+msgctxt "Messages"
+msgid "Poll to attach"
+msgstr "添付する投票"
+
+#: ../src/scenes/Messages.rb:923
+msgctxt "Messages"
+msgid "This poll has already been added"
+msgstr "この投票は既に追加されています"
+
+#: ../src/scenes/Messages.rb:927
+msgctxt "Messages"
+msgid "Poll has been added"
+msgstr "投票が追加されました"
+
+#: ../src/scenes/Messages.rb:931
+msgctxt "Messages"
+msgid "You haven't created any polls yet."
+msgstr "まだ投票を作成していません。"
+
+#: ../src/scenes/Messages.rb:940
+msgctxt "Messages"
+msgid "Delete poll"
+msgstr "投票を削除"
+
+#: ../src/scenes/Messages.rb:961
+msgctxt "Messages"
+msgid "Send as admin"
+msgstr "管理者として送信"
+
+#: ../src/scenes/Messages.rb:986 ../src/scenes/Messages.rb:1072
+msgctxt "Messages"
+msgid "The recipient cannot be found."
+msgstr "受信者が見つかりません。"
+
+#: ../src/scenes/Messages.rb:988
+msgctxt "Messages"
+msgid "Do you want to send this message as e-mail?"
+msgstr "このメッセージを電子メールとして送信しますか？"
+
+#: ../src/scenes/Notes.rb:51
+msgctxt "Notes"
+msgid "Modified"
+msgstr "更新日時"
+
+#: ../src/scenes/Notes.rb:51
+msgctxt "Notes"
+msgid "Author"
+msgstr "作成者"
+
+#: ../src/scenes/Notes.rb:53
+msgctxt "Notes"
+msgid "Notes"
+msgstr "ノート"
+
+#: ../src/scenes/Notes.rb:74
+msgctxt "Notes"
+msgid "Read"
+msgstr "読む"
+
+#: ../src/scenes/Notes.rb:77 ../src/scenes/Notes.rb:118
+msgctxt "Notes"
+msgid "Edit"
+msgstr "編集"
+
+#: ../src/scenes/Notes.rb:85
+msgctxt "Notes"
+msgid "Rename"
+msgstr "名前を変更"
+
+#: ../src/scenes/Notes.rb:89
+msgctxt "Notes"
+msgid "Don't share this note"
+msgstr "このノートを共有しない"
+
+#: ../src/scenes/Notes.rb:94
+msgctxt "Notes"
+msgid "New note"
+msgstr "新しいノート"
+
+#: ../src/scenes/Notes.rb:118
+msgctxt "Notes"
+msgid "Note shared with"
+msgstr "ノートの共有相手"
+
+#: ../src/scenes/Notes.rb:123
+msgctxt "Notes"
+msgid "Share"
+msgstr "共有"
+
+#: ../src/scenes/Notes.rb:124
+msgctxt "Notes"
+msgid "Who do you want to share this note with?"
+msgstr "このノートを誰と共有しますか？"
+
+#: ../src/scenes/Notes.rb:137
+msgctxt "Notes"
+msgid "User cannot be found"
+msgstr "ユーザーが見つかりません"
+
+#: ../src/scenes/Notes.rb:143
+msgctxt "Notes"
+msgid "From now on you share this note with %{user}"
+msgstr "これでこのノートは %{user} と共有されます"
+
+#: ../src/scenes/Notes.rb:165
+msgctxt "Notes"
+msgid "Are you sure you want to close this note without saving?"
+msgstr "保存せずにこのノートを閉じてもよろしいですか？"
+
+#: ../src/scenes/Notes.rb:183
+msgctxt "Notes"
+msgid "The note has been modified."
+msgstr "ノートが変更されました。"
+
+#: ../src/scenes/Notes.rb:190
+msgctxt "Notes"
+msgid "Do you want to stop sharing this note with %{user}?"
+msgstr "%{user} とのノートの共有を停止しますか？"
+
+#: ../src/scenes/Notes.rb:196
+msgctxt "Notes"
+msgid "You no longer share this note with %{user}"
+msgstr "このノートは %{user} と共有されなくなりました"
+
+#: ../src/scenes/Notes.rb:219
+msgctxt "Notes"
+msgid "Do you really want to delete %{name}?"
+msgstr "本当に %{name} を削除しますか？"
+
+#: ../src/scenes/Notes.rb:221
+msgctxt "Notes"
+msgid "Do you really want to end sharing %{name}? It will be deleted from your notes list."
+msgstr "本当に %{name} の共有を終了しますか？あなたのノートリストから削除されます。"
+
+#: ../src/scenes/Notes.rb:231
+msgctxt "Notes"
+msgid "The note has been deleted."
+msgstr "ノートが削除されました。"
+
+#: ../src/scenes/Notes.rb:238
+msgctxt "Notes"
+msgid "New note name"
+msgstr "新しいノート名"
+
+#: ../src/scenes/Notes.rb:243
+msgctxt "Notes"
+msgid "The note has been renamed"
+msgstr "ノートの名前が変更されました"
+
+#: ../src/scenes/Notes.rb:252
+msgctxt "Notes"
+msgid "Note content"
+msgstr "ノートの内容"
+
+#: ../src/scenes/Notes.rb:252
+msgctxt "Notes"
+msgid "Add"
+msgstr "追加"
+
+#: ../src/scenes/Notes.rb:252
+msgctxt "Notes"
+msgid "note title"
+msgstr "ノートのタイトル"
+
+#: ../src/scenes/Notes.rb:273
+msgctxt "Notes"
+msgid "The note has been created"
+msgstr "ノートが作成されました"
+
+#: ../src/scenes/Online.rb:20
+msgctxt "Online"
+msgid "%{count} user online"
+msgid_plural "%{count} users online"
+msgstr[0] "%{count} 人のユーザーがオンラインです"
+
+#: ../src/scenes/Polls.rb:12
+msgctxt "Polls"
+msgid "Votes"
+msgstr "投票数"
+
+#: ../src/scenes/Polls.rb:12
+msgctxt "Polls"
+msgid "Polls"
+msgstr "投票"
+
+#: ../src/scenes/Polls.rb:12 ../src/scenes/Polls.rb:387 ../src/scenes/Polls.rb:507
+msgctxt "Polls"
+msgid "Author"
+msgstr "作成者"
+
+#: ../src/scenes/Polls.rb:134
+msgctxt "Polls"
+msgid "Do you really want to delete %{name}?"
+msgstr "本当に %{name} を削除しますか？"
+
+#: ../src/scenes/Polls.rb:139
+msgctxt "Polls"
+msgid "deleted"
+msgstr "削除されました"
+
+#: ../src/scenes/Polls.rb:150
+msgctxt "Polls"
+msgid "Show polls in unknown languages"
+msgstr "未知の言語の投票を表示"
+
+#: ../src/scenes/Polls.rb:151
+msgctxt "Polls"
+msgid "Hide polls in unknown languages"
+msgstr "未知の言語の投票を非表示"
+
+#: ../src/scenes/Polls.rb:161
+msgctxt "Polls"
+msgid "New poll"
+msgstr "新しい投票"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Hide poll results before the expiry date"
+msgstr "有効期限前に投票結果を非表示にする"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Expiry date"
+msgstr "有効期限"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Set the expiry date for this poll"
+msgstr "この投票の有効期限を設定"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Hide this poll"
+msgstr "この投票を非表示"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Description"
+msgstr "説明"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Poll name"
+msgstr "投票名"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Create"
+msgstr "作成"
+
+#: ../src/scenes/Polls.rb:182
+msgctxt "Polls"
+msgid "Poll language"
+msgstr "投票の言語"
+
+#: ../src/scenes/Polls.rb:182 ../src/scenes/Polls.rb:619
+msgctxt "Polls"
+msgid "Questions"
+msgstr "質問"
+
+#: ../src/scenes/Polls.rb:204
+msgctxt "Polls"
+msgid "Are you sure you want to discard this poll?"
+msgstr "この投票を破棄してもよろしいですか？"
+
+#: ../src/scenes/Polls.rb:213
+msgctxt "Polls"
+msgid "New question"
+msgstr "新しい質問"
+
+#: ../src/scenes/Polls.rb:217
+msgctxt "Polls"
+msgid "Edit question"
+msgstr "質問を編集"
+
+#: ../src/scenes/Polls.rb:220
+msgctxt "Polls"
+msgid "Delete question"
+msgstr "質問を削除"
+
+#: ../src/scenes/Polls.rb:233
+msgctxt "Polls"
+msgid "Question"
+msgstr "質問"
+
+#: ../src/scenes/Polls.rb:234
+msgctxt "Polls"
+msgid "Single choice"
+msgstr "単一選択"
+
+#: ../src/scenes/Polls.rb:234
+msgctxt "Polls"
+msgid "Multiple choice"
+msgstr "複数選択"
+
+#: ../src/scenes/Polls.rb:234
+msgctxt "Polls"
+msgid "Edit box"
+msgstr "入力欄"
+
+#: ../src/scenes/Polls.rb:234
+msgctxt "Polls"
+msgid "Question type"
+msgstr "質問の種類"
+
+#: ../src/scenes/Polls.rb:235
+msgctxt "Polls"
+msgid "Limit count of answers that can be checked"
+msgstr "選択できる回答数を制限する"
+
+#: ../src/scenes/Polls.rb:236
+msgctxt "Polls"
+msgid "Count of answers that can be checked"
+msgstr "選択できる回答の数"
+
+#: ../src/scenes/Polls.rb:238 ../src/scenes/Polls.rb:620
+msgctxt "Polls"
+msgid "Answers"
+msgstr "回答"
+
+#: ../src/scenes/Polls.rb:290
+msgctxt "Polls"
+msgid "There are no answers to this question"
+msgstr "この質問には回答がありません"
+
+#: ../src/scenes/Polls.rb:292
+msgctxt "Polls"
+msgid "There is only one answer to this question."
+msgstr "この質問には1つの回答しかありません"
+
+#: ../src/scenes/Polls.rb:304
+msgctxt "Polls"
+msgid "New answer"
+msgstr "新しい回答"
+
+#: ../src/scenes/Polls.rb:308
+msgctxt "Polls"
+msgid "Edit answer"
+msgstr "回答を編集"
+
+#: ../src/scenes/Polls.rb:311
+msgctxt "Polls"
+msgid "Delete answer"
+msgstr "回答を削除"
+
+#: ../src/scenes/Polls.rb:321
+msgctxt "Polls"
+msgid "Answer"
+msgstr "回答"
+
+#: ../src/scenes/Polls.rb:330
+msgctxt "Polls"
+msgid "Please complete the poll before sending"
+msgstr "送信する前に投票を完了してください"
+
+#: ../src/scenes/Polls.rb:344
+msgctxt "Polls"
+msgid "The poll has been created."
+msgstr "投票が作成されました。"
+
+#: ../src/scenes/Polls.rb:387 ../src/scenes/Polls.rb:507
+msgctxt "Polls"
+msgid "Created"
+msgstr "作成日"
+
+#: ../src/scenes/Polls.rb:398
+msgctxt "Polls"
+msgid "Single choice question"
+msgstr "単一選択質問"
+
+#: ../src/scenes/Polls.rb:402
+msgctxt "Polls"
+msgid "Multiple choice question"
+msgstr "複数選択質問"
+
+#: ../src/scenes/Polls.rb:406
+msgctxt "Polls"
+msgid "Up to %{limit}-choice question"
+msgid_plural "Up to %{limit}-choices question"
+msgstr[0] "最大 %{limit} 個の回答を選択できる質問"
+
+#: ../src/scenes/Polls.rb:416
+msgctxt "Polls"
+msgid "Poll"
+msgstr "投票"
+
+#: ../src/scenes/Polls.rb:422
+msgctxt "Polls"
+msgid "Are you sure you want to discard your answers in this poll?"
+msgstr "この投票での回答を破棄してもよろしいですか？"
+
+#: ../src/scenes/Polls.rb:458
+msgctxt "Polls"
+msgid "Your vote has been saved."
+msgstr "あなたの投票が保存されました。"
+
+#: ../src/scenes/Polls.rb:518
+msgctxt "Polls"
+msgid "The number of votes"
+msgstr "投票数"
+
+#: ../src/scenes/Polls.rb:548
+msgctxt "Polls"
+msgid "Poll results: %{name}"
+msgstr "投票結果：%{name}"
+
+#: ../src/scenes/Polls.rb:621
+msgctxt "Polls"
+msgid "Filters"
+msgstr "フィルター"
+
+#: ../src/scenes/Polls.rb:643
+msgctxt "Polls"
+msgid "Filter with this answer"
+msgstr "この回答でフィルター"
+
+#: ../src/scenes/Polls.rb:647
+msgctxt "Polls"
+msgid "Filter without this answer"
+msgstr "この回答を除外してフィルター"
+
+#: ../src/scenes/Polls.rb:652
+msgctxt "Polls"
+msgid "Delete this answer from filters"
+msgstr "フィルターからこの回答を削除"
+
+#: ../src/scenes/Polls.rb:732
+msgctxt "Polls"
+msgid "Includes"
+msgstr "含む"
+
+#: ../src/scenes/Polls.rb:734
+msgctxt "Polls"
+msgid "Excludes"
+msgstr "除外"
+
+#: ../src/scenes/Portable.rb:9
+msgctxt "Portable"
+msgid "Copy current settings"
+msgstr "現在の設定をコピー"
+
+#: ../src/scenes/Portable.rb:9
+msgctxt "Portable"
+msgid "Copy downloaded sound themes"
+msgstr "ダウンロードしたサウンドテーマをコピー"
+
+#: ../src/scenes/Portable.rb:9
+msgctxt "Portable"
+msgid "continue"
+msgstr "続行"
+
+#: ../src/scenes/Portable.rb:9
+msgctxt "Portable"
+msgid "Destination"
+msgstr "保存先"
+
+#: ../src/scenes/Portable.rb:23
+msgctxt "Portable"
+msgid "Please wait while files are being prepared"
+msgstr "ファイルの準備中です。しばらくお待ちください"
+
+#: ../src/scenes/Portable.rb:31
+msgctxt "Portable"
+msgid "Copying settings"
+msgstr "設定をコピー中"
+
+#: ../src/scenes/Portable.rb:36
+msgctxt "Portable"
+msgid "If you use a created copy of Elten on another computer, the voice settings may  not work properly. This is especially noticeable in a situation when another  computer has other voices installed. How do you want to configure the generated  version?"
+msgstr "作成したエルテンのコピーを他のコンピュータで使用する場合、音声の設定が正しく動作しない可能性があります。特に、別のコンピュータに他の音声がインストールされている場合に顕著です。生成されたバージョンをどのように設定しますか？"
+
+#: ../src/scenes/Portable.rb:36
+msgctxt "Portable"
+msgid "Use a screenreader or a system default voice"
+msgstr "スクリーンリーダーまたはシステムのデフォルト音声を使用"
+
+#: ../src/scenes/Portable.rb:36
+msgctxt "Portable"
+msgid "Use current setting"
+msgstr "現在の設定を使用"
+
+#: ../src/scenes/Portable.rb:36
+msgctxt "Portable"
+msgid "Reset synthesizer settings"
+msgstr "音声合成の設定をリセット"
+
+#: ../src/scenes/Portable.rb:36
+msgctxt "Portable"
+msgid "Ask each time"
+msgstr "毎回確認する"
+
+#: ../src/scenes/Portable.rb:47
+msgctxt "Portable"
+msgid "Copying sound themes"
+msgstr "サウンドテーマをコピー中"
+
+#: ../src/scenes/Portable.rb:60
+msgctxt "Portable"
+msgid "Elten Portable version created successfully."
+msgstr "エルテンのポータブル版が正常に作成されました。"
+
+#: ../src/scenes/Programs.rb:42
+msgctxt "Programs"
+msgid "not installed"
+msgstr "未インストール"
+
+#: ../src/scenes/Programs.rb:45
+msgctxt "Programs"
+msgid "Programs installation"
+msgstr "プログラムのインストール"
+
+#: ../src/scenes/Programs.rb:59
+msgctxt "Programs"
+msgid "Install"
+msgstr "インストール"
+
+#: ../src/scenes/Programs.rb:65
+msgctxt "Programs"
+msgid "Reinstall"
+msgstr "再インストール"
+
+#: ../src/scenes/Programs.rb:67
+msgctxt "Programs"
+msgid "Update"
+msgstr "更新"
+
+#: ../src/scenes/Programs.rb:83
+msgctxt "Programs"
+msgid "Do you want to install program %{name}? Need to download %{size} of data."
+msgstr "プログラム %{name} をインストールしますか？%{size} のデータをダウンロードする必要があります。"
+
+#: ../src/scenes/Programs.rb:104
+msgctxt "Programs"
+msgid "Installation canceled."
+msgstr "インストールがキャンセルされました。"
+
+#: ../src/scenes/Programs.rb:111
+msgctxt "Programs"
+msgid "Installation completed."
+msgstr "インストールが完了しました。"
+
+#: ../src/scenes/Programs.rb:120
+msgctxt "Programs"
+msgid "Remove"
+msgstr "削除"
+
+#: ../src/scenes/Programs.rb:121
+msgctxt "Programs"
+msgid "Are you sure you want to remove program %{name}?"
+msgstr "本当にプログラム %{name} を削除しますか？"
+
+#: ../src/scenes/Programs.rb:124
+msgctxt "Programs"
+msgid "Program removed"
+msgstr "プログラムが削除されました"
+
+#: ../src/scenes/Registration.rb:13
+msgctxt "Registration"
+msgid "Enter your username. It will be used for identification.The maximum length of the  username is 64 characters"
+msgstr "ユーザー名を入力してください。これは識別に使用されます。ユーザー名の最大長は64文字です。"
+
+#: ../src/scenes/Registration.rb:16
+msgctxt "Registration"
+msgid "User with this name already exists."
+msgstr "この名前のユーザーは既に存在します。"
+
+#: ../src/scenes/Registration.rb:27
+msgctxt "Registration"
+msgid "Enter your password. It is recommended to use a strong password, which consists  of numbers and letters. Maximum length of the password is 256 characters."
+msgstr "パスワードを入力してください。数字と文字を組み合わせた強力なパスワードの使用を推奨します。パスワードの最大長は256文字です。"
+
+#: ../src/scenes/Registration.rb:29
+msgctxt "Registration"
+msgid "Reenter your password"
+msgstr "パスワードを再入力してください"
+
+#: ../src/scenes/Registration.rb:32
+msgctxt "Registration"
+msgid "The entered passwords differ"
+msgstr "入力されたパスワードが異なります"
+
+#: ../src/scenes/Registration.rb:40
+msgctxt "Registration"
+msgid "Enter your e-mail address. It will be used in case you forget your password and  to send important information."
+msgstr "メールアドレスを入力してください。パスワードを忘れた場合や重要な情報を送信するために使用されます。"
+
+#: ../src/scenes/Registration.rb:51
+msgctxt "Registration"
+msgid "Registration is successful, thank you. You can log in using your username and  password."
+msgstr "登録が成功しました。ありがとうございます。ユーザー名とパスワードでログインできます。"
+
+#: ../src/scenes/Registration.rb:53
+msgctxt "Registration"
+msgid "An unknown error occurred while using database"
+msgstr "データベース使用中に不明なエラーが発生しました"
+
+#: ../src/scenes/Registration.rb:55
+msgctxt "Registration"
+msgid "Account with the specified username already exists."
+msgstr "指定されたユーザー名のアカウントは既に存在します。"
+
+#: ../src/scenes/Registration.rb:57
+msgctxt "Registration"
+msgid "An error occurred while trying to write data."
+msgstr "データの書き込み中にエラーが発生しました。"
+
+#: ../src/scenes/Registration.rb:59
+msgctxt "Registration"
+msgid "An error occurred while connecting to the server."
+msgstr "サーバーへの接続中にエラーが発生しました。"
+
+#: ../src/scenes/Settings.rb:116
+msgctxt "Settings"
+msgid "Category"
+msgstr "カテゴリー"
+
+#: ../src/scenes/Settings.rb:122
+msgctxt "Settings"
+msgid "General"
+msgstr "一般"
+
+#: ../src/scenes/Settings.rb:130
+msgctxt "Settings"
+msgid "Language"
+msgstr "言語"
+
+#: ../src/scenes/Settings.rb:131
+msgctxt "Settings"
+msgid "Automatically minimize Elten Window to system tray"
+msgstr "Eltenウィンドウを自動的にシステムトレイに最小化する"
+
+#: ../src/scenes/Settings.rb:132
+msgctxt "Settings"
+msgid "Enable auto log in"
+msgstr "自動ログインを有効にする"
+
+#: ../src/scenes/Settings.rb:133
+msgctxt "Settings"
+msgid "Automatically start Elten after I log on to Windows"
+msgstr "Windowsにログオン後、Eltenを自動的に開始する"
+
+#: ../src/scenes/Settings.rb:134
+msgctxt "Settings"
+msgid "Check for updates at startup"
+msgstr "起動時に更新を確認する"
+
+#: ../src/scenes/Settings.rb:135
+msgctxt "Settings"
+msgid "Updates branch"
+msgstr "更新のブランチ"
+
+#: ../src/scenes/Settings.rb:135
+msgctxt "Settings"
+msgid "Auto"
+msgstr "自動"
+
+#: ../src/scenes/Settings.rb:135
+msgctxt "Settings"
+msgid "Stable"
+msgstr "安定版"
+
+#: ../src/scenes/Settings.rb:135
+msgctxt "Settings"
+msgid "Beta"
+msgstr "ベータ"
+
+#: ../src/scenes/Settings.rb:135
+msgctxt "Settings"
+msgid "RC"
+msgstr "リリース候補"
+
+#: ../src/scenes/Settings.rb:136
+msgctxt "Settings"
+msgid "Send Elten usage reports"
+msgstr "エルテンの使用レポートを送信する"
+
+#: ../src/scenes/Settings.rb:139
+msgctxt "Settings"
+msgid "Interface"
+msgstr "インターフェース"
+
+#: ../src/scenes/Settings.rb:140
+msgctxt "Settings"
+msgid "Play sounds of sound themes"
+msgstr "サウンドテーマの音を再生する"
+
+#: ../src/scenes/Settings.rb:141
+msgctxt "Settings"
+msgid "Soundtheme volume"
+msgstr "サウンドテーマの音量"
+
+#: ../src/scenes/Settings.rb:142
+msgctxt "Settings"
+msgid "Use default"
+msgstr "デフォルトを使用"
+
+#: ../src/scenes/Settings.rb:155
+msgctxt "Settings"
+msgid "Sound theme"
+msgstr "サウンドテーマ"
+
+#: ../src/scenes/Settings.rb:156
+msgctxt "Settings"
+msgid "Manage sound themes"
+msgstr "サウンドテーマを管理する"
+
+#: ../src/scenes/Settings.rb:157
+msgctxt "Settings"
+msgid "Use Stereo positioning for user interface"
+msgstr "ユーザーインターフェースにステレオポジショニングを使用する"
+
+#: ../src/scenes/Settings.rb:158
+msgctxt "Settings"
+msgid "Use background sounds in menu and dialog windows"
+msgstr "メニューとダイアログウィンドウで背景音を使用する"
+
+#: ../src/scenes/Settings.rb:159
+msgctxt "Settings"
+msgid "Display context menu in menu bar"
+msgstr "コンテキストメニューをメニューバーに表示する"
+
+#: ../src/scenes/Settings.rb:160 ../src/scenes/Settings.rb:248
+msgctxt "Settings"
+msgid "Voice only"
+msgstr "音声のみ"
+
+#: ../src/scenes/Settings.rb:160 ../src/scenes/Settings.rb:248
+msgctxt "Settings"
+msgid "Voice and sound"
+msgstr "音声と音"
+
+#: ../src/scenes/Settings.rb:160
+msgctxt "Settings"
+msgid "Control types announcement"
+msgstr "コントロールタイプの通知"
+
+#: ../src/scenes/Settings.rb:160 ../src/scenes/Settings.rb:248
+msgctxt "Settings"
+msgid "Sound only"
+msgstr "音のみ"
+
+#: ../src/scenes/Settings.rb:161
+msgctxt "Settings"
+msgid "Wrap long lines in text fields"
+msgstr "テキストフィールドで長い行を折り返す"
+
+#: ../src/scenes/Settings.rb:162
+msgctxt "Settings"
+msgid "The display method of selection lists"
+msgstr "選択リストの表示方法"
+
+#: ../src/scenes/Settings.rb:162
+msgctxt "Settings"
+msgid "Linear"
+msgstr "リニア"
+
+#: ../src/scenes/Settings.rb:162
+msgctxt "Settings"
+msgid "Circular"
+msgstr "サーキュラー"
+
+#: ../src/scenes/Settings.rb:163
+msgctxt "Settings"
+msgid "Round up the forms"
+msgstr "フォームを丸める"
+
+#: ../src/scenes/Settings.rb:164
+msgctxt "Settings"
+msgid "Disable feed notifications"
+msgstr "フィード通知を無効にする"
+
+#: ../src/scenes/Settings.rb:165
+msgctxt "Settings"
+msgid "Only when transcription is not available"
+msgstr "文字起こしが利用できない場合のみ"
+
+#: ../src/scenes/Settings.rb:165
+msgctxt "Settings"
+msgid "Always"
+msgstr "常に"
+
+#: ../src/scenes/Settings.rb:165 ../src/scenes/Settings.rb:299
+msgctxt "Settings"
+msgid "Never"
+msgstr "決して"
+
+#: ../src/scenes/Settings.rb:165
+msgctxt "Settings"
+msgid "Automatically play audio content"
+msgstr "音声コンテンツを自動再生する"
+
+#: ../src/scenes/Settings.rb:186 ../src/scenes/Settings.rb:190
+msgctxt "Settings"
+msgid "Voice"
+msgstr "音声"
+
+#: ../src/scenes/Settings.rb:188
+msgctxt "Settings"
+msgid "Use NVDA"
+msgstr "NVDAを使用する"
+
+#: ../src/scenes/Settings.rb:191
+msgctxt "Settings"
+msgid "Speech rate"
+msgstr "読み上げ速度"
+
+#: ../src/scenes/Settings.rb:192
+msgctxt "Settings"
+msgid "Speech volume"
+msgstr "読み上げ音量"
+
+#: ../src/scenes/Settings.rb:193
+msgctxt "Settings"
+msgid "Speech pitch"
+msgstr "読み上げピッチ"
+
+#: ../src/scenes/Settings.rb:194
+msgctxt "Settings"
+msgid "Enable braille output (requires NVDA addon)"
+msgstr "点字出力を有効にする（NVDAアドオンが必要）"
+
+#: ../src/scenes/Settings.rb:195
+msgctxt "Settings"
+msgid "Use a voice dictionary when processing characters (requires NVDA addon when using NVDA as a speech output)"
+msgstr "文字を処理する際に音声辞書を使用する（NVDAを音声出力に使用している場合はNVDAアドオンが必要）"
+
+#: ../src/scenes/Settings.rb:196
+msgctxt "Settings"
+msgid "Words"
+msgstr "単語"
+
+#: ../src/scenes/Settings.rb:196 ../src/scenes/Settings.rb:248
+msgctxt "Settings"
+msgid "None"
+msgstr "なし"
+
+#: ../src/scenes/Settings.rb:196
+msgctxt "Settings"
+msgid "Characters and words"
+msgstr "文字と単語"
+
+#: ../src/scenes/Settings.rb:196
+msgctxt "Settings"
+msgid "Characters"
+msgstr "文字"
+
+#: ../src/scenes/Settings.rb:196
+msgctxt "Settings"
+msgid "Typing echo"
+msgstr "入力エコー"
+
+#: ../src/scenes/Settings.rb:247
+msgctxt "Settings"
+msgid "Clock"
+msgstr "時計"
+
+#: ../src/scenes/Settings.rb:248
+msgctxt "Settings"
+msgid "Clock information"
+msgstr "時計の情報"
+
+#: ../src/scenes/Settings.rb:249
+msgctxt "Settings"
+msgid "every half hour"
+msgstr "30分ごと"
+
+#: ../src/scenes/Settings.rb:249
+msgctxt "Settings"
+msgid "announcement time"
+msgstr "通知時間"
+
+#: ../src/scenes/Settings.rb:249
+msgctxt "Settings"
+msgid "every quarter of an hour"
+msgstr "15分ごと"
+
+#: ../src/scenes/Settings.rb:249
+msgctxt "Settings"
+msgid "every hour"
+msgstr "毎時"
+
+#: ../src/scenes/Settings.rb:250
+msgctxt "Settings"
+msgid "Alarms"
+msgstr "アラーム"
+
+#: ../src/scenes/Settings.rb:263
+msgctxt "Settings"
+msgid "Sound devices"
+msgstr "サウンドデバイス"
+
+#: ../src/scenes/Settings.rb:267 ../src/scenes/Settings.rb:269
+msgctxt "Settings"
+msgid "Use Default"
+msgstr "デフォルトを使用"
+
+#: ../src/scenes/Settings.rb:293
+msgctxt "Settings"
+msgid "Loopback device"
+msgstr "ループバックデバイス"
+
+#: ../src/scenes/Settings.rb:296
+msgctxt "Settings"
+msgid "Output device"
+msgstr "出力デバイス"
+
+#: ../src/scenes/Settings.rb:297
+msgctxt "Settings"
+msgid "Input device"
+msgstr "入力デバイス"
+
+#: ../src/scenes/Settings.rb:298
+msgctxt "Settings"
+msgid "Mute the microphone in conferences while recording other content"
+msgstr "他のコンテンツを録音中は会議でマイクをミュートにする"
+
+#: ../src/scenes/Settings.rb:299
+msgctxt "Settings"
+msgid "In audio conferences only"
+msgstr "音声会議のみ"
+
+#: ../src/scenes/Settings.rb:299
+msgctxt "Settings"
+msgid "In audio conferences and when recording"
+msgstr "音声会議と録音時"
+
+#: ../src/scenes/Settings.rb:299
+msgctxt "Settings"
+msgid "Use noise reduction"
+msgstr "ノイズリダクションを使用する"
+
+#: ../src/scenes/Settings.rb:300
+msgctxt "Settings"
+msgid "Enable echo cancellation"
+msgstr "エコーキャンセレーションを有効にする"
+
+#: ../src/scenes/Settings.rb:303
+msgctxt "Settings"
+msgid "Invisible interface"
+msgstr "不可視インターフェース"
+
+#: ../src/scenes/Settings.rb:314
+msgctxt "Settings"
+msgid "Modifier keys"
+msgstr "修飾キー"
+
+#: ../src/scenes/Settings.rb:315
+msgctxt "Settings"
+msgid "Feed"
+msgstr "フィード"
+
+#: ../src/scenes/Settings.rb:315
+msgctxt "Settings"
+msgid "Cards to show"
+msgstr "表示するカード"
+
+#: ../src/scenes/Settings.rb:315
+msgctxt "Settings"
+msgid "Messages"
+msgstr "メッセージ"
+
+#: ../src/scenes/Settings.rb:315
+msgctxt "Settings"
+msgid "Conference options"
+msgstr "会議のオプション"
+
+#: ../src/scenes/Settings.rb:318
+msgctxt "Settings"
+msgid "Advanced"
+msgstr "詳細設定"
+
+#: ../src/scenes/Settings.rb:319
+msgctxt "Settings"
+msgid "Enable FX effects"
+msgstr "FX効果を有効にする"
+
+#: ../src/scenes/Settings.rb:320
+msgctxt "Settings"
+msgid "Use bilinear HRTF interpolation"
+msgstr "バイリニアHRTF補間を使用する"
+
+#: ../src/scenes/Settings.rb:321
+msgctxt "Settings"
+msgid "Disable concurrent requests (HTTP2)"
+msgstr "同時リクエストを無効にする（HTTP2）"
+
+#: ../src/scenes/Settings.rb:322
+msgctxt "Settings"
+msgid "Use only TCP packets in conferences"
+msgstr "会議でTCPパケットのみを使用する"
+
+#: ../src/scenes/Settings.rb:323
+msgctxt "Settings"
+msgid "Maximum UDP packet payload size"
+msgstr "最大UDPパケットペイロードサイズ"
+
+#: ../src/scenes/Settings.rb:324
+msgctxt "Settings"
+msgid "Conferences audio buffer in frames"
+msgstr "会議のオーディオバッファ（フレーム数）"
+
+#: ../src/scenes/Settings.rb:325
+msgctxt "Settings"
+msgid "Conference buffer cut-off threshold in milliseconds"
+msgstr "会議バッファのカットオフしきい値（ミリ秒）"
+
+#: ../src/scenes/SoundThemes.rb:21
+msgctxt "SoundThemes"
+msgid "default"
+msgstr "デフォルト"
+
+#: ../src/scenes/SoundThemes.rb:24
+msgctxt "SoundThemes"
+msgid "Sound themes"
+msgstr "サウンドテーマ"
+
+#: ../src/scenes/SoundThemes.rb:41
+msgctxt "SoundThemes"
+msgid "Select"
+msgstr "選択"
+
+#: ../src/scenes/SoundThemes.rb:44
+msgctxt "SoundThemes"
+msgid "Download sound themes"
+msgstr "サウンドテーマをダウンロード"
+
+#: ../src/scenes/SoundThemes.rb:48
+msgctxt "SoundThemes"
+msgid "New"
+msgstr "新規"
+
+#: ../src/scenes/SoundThemes.rb:52
+msgctxt "SoundThemes"
+msgid "Edit"
+msgstr "編集"
+
+#: ../src/scenes/SoundThemes.rb:55 ../src/scenes/SoundThemes.rb:167
+msgctxt "SoundThemes"
+msgid "Delete"
+msgstr "削除"
+
+#: ../src/scenes/SoundThemes.rb:56
+msgctxt "SoundThemes"
+msgid "Are you sure you want to delete this soundtheme?"
+msgstr "本当にこのサウンドテーマを削除しますか？"
+
+#: ../src/scenes/SoundThemes.rb:65
+msgctxt "SoundThemes"
+msgid "Do you wish to use this sound theme?"
+msgstr "このサウンドテーマを使用しますか？"
+
+#: ../src/scenes/SoundThemes.rb:98
+msgctxt "SoundThemes"
+msgid "Most popular"
+msgstr "最も人気のある"
+
+#: ../src/scenes/SoundThemes.rb:98
+msgctxt "SoundThemes"
+msgid "Available sound themes"
+msgstr "利用可能なサウンドテーマ"
+
+#: ../src/scenes/SoundThemes.rb:98
+msgctxt "SoundThemes"
+msgid "Recently added"
+msgstr "最近追加された"
+
+#: ../src/scenes/SoundThemes.rb:130
+msgctxt "SoundThemes"
+msgid "Not downloaded"
+msgstr "未ダウンロード"
+
+#: ../src/scenes/SoundThemes.rb:135
+msgctxt "SoundThemes"
+msgid "Update available"
+msgstr "更新があります"
+
+#: ../src/scenes/SoundThemes.rb:137
+msgctxt "SoundThemes"
+msgid "Downloaded"
+msgstr "ダウンロード済み"
+
+#: ../src/scenes/SoundThemes.rb:144
+msgctxt "SoundThemes"
+msgid "Used by"
+msgstr "使用者"
+
+#: ../src/scenes/SoundThemes.rb:144
+msgctxt "SoundThemes"
+msgid "Status"
+msgstr "ステータス"
+
+#: ../src/scenes/SoundThemes.rb:144
+msgctxt "Soundthemes"
+msgid "Select theme to download"
+msgstr "ダウンロードするテーマを選択"
+
+#: ../src/scenes/SoundThemes.rb:144
+msgctxt "SoundThemes"
+msgid "Author"
+msgstr "作者"
+
+#: ../src/scenes/SoundThemes.rb:150
+msgctxt "SoundThemes"
+msgid "Download"
+msgstr "ダウンロード"
+
+#: ../src/scenes/SoundThemes.rb:159 ../src/scenes/SoundThemes.rb:193
+msgctxt "SoundThemes"
+msgid "Do you want to download theme %{name}? Need to download %{size} of data."
+msgstr "テーマ %{name} をダウンロードしますか？%{size} のデータをダウンロードする必要があります。"
+
+#: ../src/scenes/SoundThemes.rb:168
+msgctxt "SoundThemes"
+msgid "Are you sure you want to delete sound theme %{name} from the server?"
+msgstr "本当にサーバーからサウンドテーマ %{name} を削除しますか？"
+
+#: ../src/scenes/Sounds.rb:14
+msgctxt "Sounds"
+msgid "Operation cancelled"
+msgstr "操作がキャンセルされました"
+
+#: ../src/scenes/Sounds.rb:15
+msgctxt "Sounds"
+msgid "Background of dialog windows"
+msgstr "ダイアログウィンドウの背景"
+
+#: ../src/scenes/Sounds.rb:16
+msgctxt "Sounds"
+msgid "Dialog window opened"
+msgstr "ダイアログウィンドウが開きました"
+
+#: ../src/scenes/Sounds.rb:17
+msgctxt "Sounds"
+msgid "Dialog window closed"
+msgstr "ダイアログウィンドウが閉じました"
+
+#: ../src/scenes/Sounds.rb:18
+msgctxt "Sounds"
+msgid "Menu Background"
+msgstr "メニューの背景"
+
+#: ../src/scenes/Sounds.rb:19
+msgctxt "Sounds"
+msgid "Menu opened"
+msgstr "メニューが開きました"
+
+#: ../src/scenes/Sounds.rb:20
+msgctxt "Sounds"
+msgid "Menu closed"
+msgstr "メニューが閉じました"
+
+#: ../src/scenes/Sounds.rb:21
+msgctxt "Sounds"
+msgid "Marker of a form"
+msgstr "フォームのマーカー"
+
+#: ../src/scenes/Sounds.rb:22
+msgctxt "Sounds"
+msgid "Marker of a listbox"
+msgstr "リストボックスのマーカー"
+
+#: ../src/scenes/Sounds.rb:23
+msgctxt "Sounds"
+msgid "Marker of a multiselect listbox"
+msgstr "複数選択リストボックスのマーカー"
+
+#: ../src/scenes/Sounds.rb:24
+msgctxt "Sounds"
+msgid "Focus move on a listbox"
+msgstr "リストボックスでのフォーカス移動"
+
+#: ../src/scenes/Sounds.rb:25
+msgctxt "Sounds"
+msgid "Border of a listbox"
+msgstr "リストボックスの境界"
+
+#: ../src/scenes/Sounds.rb:26
+msgctxt "Sounds"
+msgid "Expandable item on a listbox"
+msgstr "リストボックスの展開可能な項目"
+
+#: ../src/scenes/Sounds.rb:27
+msgctxt "Sounds"
+msgid "Item expanded"
+msgstr "項目が展開されました"
+
+#: ../src/scenes/Sounds.rb:28
+msgctxt "Sounds"
+msgid "Item collapsed"
+msgstr "項目が折りたたまれました"
+
+#: ../src/scenes/Sounds.rb:29
+msgctxt "Sounds"
+msgid "Item selected"
+msgstr "項目が選択されました"
+
+#: ../src/scenes/Sounds.rb:30
+msgctxt "Sounds"
+msgid "Ticked item on a listbox"
+msgstr "リストボックスのチェックされた項目"
+
+#: ../src/scenes/Sounds.rb:31
+msgctxt "Sounds"
+msgid "Unticked item on a listbox"
+msgstr "リストボックスの未チェックの項目"
+
+#: ../src/scenes/Sounds.rb:32
+msgctxt "Sounds"
+msgid "New or updated item on a listbox"
+msgstr "リストボックスの新規または更新された項目"
+
+#: ../src/scenes/Sounds.rb:33
+msgctxt "Sounds"
+msgid "Item with attachment on a listbox"
+msgstr "リストボックスの添付ファイル付き項目"
+
+#: ../src/scenes/Sounds.rb:34
+msgctxt "Sounds"
+msgid "Closed item on a listbox"
+msgstr "リストボックスの閉じた項目"
+
+#: ../src/scenes/Sounds.rb:35
+msgctxt "Sounds"
+msgid "Item containing other items on a listbox"
+msgstr "リストボックスの他の項目を含む項目"
+
+#: ../src/scenes/Sounds.rb:36
+msgctxt "Sounds"
+msgid "Future item on a listbox"
+msgstr "リストボックスの将来の項目"
+
+#: ../src/scenes/Sounds.rb:37
+msgctxt "Sounds"
+msgid "Liked item on a listbox"
+msgstr "リストボックスの「いいね！」された項目"
+
+#: ../src/scenes/Sounds.rb:38
+msgctxt "Sounds"
+msgid "Pinned item on a listbox"
+msgstr "リストボックスのピン留めされた項目"
+
+#: ../src/scenes/Sounds.rb:39
+msgctxt "Sounds"
+msgid "Item with restricted access on a listbox"
+msgstr "リストボックスのアクセス制限付き項目"
+
+#: ../src/scenes/Sounds.rb:40
+msgctxt "Sounds"
+msgid "Online user"
+msgstr "オンラインユーザー"
+
+#: ../src/scenes/Sounds.rb:41
+msgctxt "Sounds"
+msgid "User being a sponsor"
+msgstr "スポンサーであるユーザー"
+
+#: ../src/scenes/Sounds.rb:42
+msgctxt "Sounds"
+msgid "Compressed file on a files tree"
+msgstr "ファイルツリーの圧縮ファイル"
+
+#: ../src/scenes/Sounds.rb:43
+msgctxt "Sounds"
+msgid "Audio file on a files tree"
+msgstr "ファイルツリーのオーディオファイル"
+
+#: ../src/scenes/Sounds.rb:44
+msgctxt "Sounds"
+msgid "Directory on a files tree"
+msgstr "ファイルツリーのディレクトリ"
+
+#: ../src/scenes/Sounds.rb:45
+msgctxt "Sounds"
+msgid "Document on a files tree"
+msgstr "ファイルツリーのドキュメント"
+
+#: ../src/scenes/Sounds.rb:46
+msgctxt "Sounds"
+msgid "Text file on a files tree"
+msgstr "ファイルツリーのテキストファイル"
+
+#: ../src/scenes/Sounds.rb:47
+msgctxt "Sounds"
+msgid "Marker of an editbox with audio in a form"
+msgstr "フォーム内の音声付き編集ボックスのマーカー"
+
+#: ../src/scenes/Sounds.rb:48
+msgctxt "Sounds"
+msgid "Marker of an editbox in a form"
+msgstr "フォーム内の編集ボックスのマーカー"
+
+#: ../src/scenes/Sounds.rb:49
+msgctxt "Sounds"
+msgid "A piece of text in an editbox has been selected"
+msgstr "編集ボックス内のテキストが選択されました"
+
+#: ../src/scenes/Sounds.rb:50
+msgctxt "Sounds"
+msgid "A piece of text in an editbox has been unselected"
+msgstr "編集ボックス内のテキストの選択が解除されました"
+
+#: ../src/scenes/Sounds.rb:51
+msgctxt "Sounds"
+msgid "Capitalized letter in an editbox"
+msgstr "編集ボックス内の大文字"
+
+#: ../src/scenes/Sounds.rb:52
+msgctxt "Sounds"
+msgid "Delete of a text in an editbox"
+msgstr "編集ボックス内のテキストの削除"
+
+#: ../src/scenes/Sounds.rb:53
+msgctxt "Sounds"
+msgid "End of line in an editbox"
+msgstr "編集ボックス内の行末"
+
+#: ../src/scenes/Sounds.rb:54
+msgctxt "Sounds"
+msgid "Password character in an editbox"
+msgstr "編集ボックス内のパスワード文字"
+
+#: ../src/scenes/Sounds.rb:55
+msgctxt "Sounds"
+msgid "Space in an editbox"
+msgstr "編集ボックス内のスペース"
+
+#: ../src/scenes/Sounds.rb:56
+msgctxt "Sounds"
+msgid "Marker of a button in a form"
+msgstr "フォーム内のボタンのマーカー"
+
+#: ../src/scenes/Sounds.rb:57
+msgctxt "Sounds"
+msgid "Marker of a checkbox in a form"
+msgstr "フォーム内のチェックボックスのマーカー"
+
+#: ../src/scenes/Sounds.rb:58
+msgctxt "Sounds"
+msgid "Feed updated"
+msgstr "フィードが更新されました"
+
+#: ../src/scenes/Sounds.rb:59
+msgctxt "Sounds"
+msgid "Mentioned in a feed"
+msgstr "フィードで言及されました"
+
+#: ../src/scenes/Sounds.rb:60
+msgctxt "Sounds"
+msgid "User signed in or Elten window focused"
+msgstr "ユーザーがサインイン、またはEltenウィンドウがフォーカスされました"
+
+#: ../src/scenes/Sounds.rb:61
+msgctxt "Sounds"
+msgid "User signed out or Elten closed"
+msgstr "ユーザーがサインアウト、またはEltenが閉じられました"
+
+#: ../src/scenes/Sounds.rb:62
+msgctxt "Sounds"
+msgid "Elten minimized into tray"
+msgstr "Eltenがトレイに最小化されました"
+
+#: ../src/scenes/Sounds.rb:63
+msgctxt "Sounds"
+msgid "Messages window updated"
+msgstr "メッセージウィンドウが更新されました"
+
+#: ../src/scenes/Sounds.rb:64
+msgctxt "Sounds"
+msgid "New event"
+msgstr "新しいイベント"
+
+#: ../src/scenes/Sounds.rb:65
+msgctxt "Sounds"
+msgid "Notification: birthday of a friend"
+msgstr "通知：友達の誕生日"
+
+#: ../src/scenes/Sounds.rb:66
+msgctxt "Sounds"
+msgid "Notification: new comment on your blog"
+msgstr "通知：あなたのブログへの新しいコメント"
+
+#: ../src/scenes/Sounds.rb:67
+msgctxt "Sounds"
+msgid "Notification: new follower of your blog"
+msgstr "通知：あなたのブログの新しいフォロワー"
+
+#: ../src/scenes/Sounds.rb:68
+msgctxt "Sounds"
+msgid "Notification: new blog mention"
+msgstr "通知：新しいブログの言及"
+
+#: ../src/scenes/Sounds.rb:69
+msgctxt "Sounds"
+msgid "Notification: new post on a followed blog"
+msgstr "通知：フォロー中のブログの新しい投稿"
+
+#: ../src/scenes/Sounds.rb:70
+msgctxt "Sounds"
+msgid "Notification: new comment to a followed blog post"
+msgstr "通知：フォロー中のブログ投稿への新しいコメント"
+
+#: ../src/scenes/Sounds.rb:71
+msgctxt "Sounds"
+msgid "Notification: new thread on a followed forum"
+msgstr "通知：フォロー中のフォーラムの新しいスレッド"
+
+#: ../src/scenes/Sounds.rb:72
+msgctxt "Sounds"
+msgid "Notification: new post on a followed forum"
+msgstr "通知：フォロー中のフォーラムの新しい投稿"
+
+#: ../src/scenes/Sounds.rb:73
+msgctxt "Sounds"
+msgid "Notification: new post in a followed thread"
+msgstr "通知：フォロー中のスレッドの新しい投稿"
+
+#: ../src/scenes/Sounds.rb:74
+msgctxt "Sounds"
+msgid "Notification: new friend"
+msgstr "通知：新しい友達"
+
+#: ../src/scenes/Sounds.rb:75
+msgctxt "Sounds"
+msgid "Notification: new invitation to a group"
+msgstr "通知：グループへの新しい招待"
+
+#: ../src/scenes/Sounds.rb:76
+msgctxt "Sounds"
+msgid "Notification: new mention"
+msgstr "通知：新しいメンション"
+
+#: ../src/scenes/Sounds.rb:77
+msgctxt "Sounds"
+msgid "Notification: new message"
+msgstr "通知：新しいメッセージ"
+
+#: ../src/scenes/Sounds.rb:78
+msgctxt "Sounds"
+msgid "Notification: online monitor"
+msgstr "通知：オンラインモニター"
+
+#: ../src/scenes/Sounds.rb:79
+msgctxt "Sounds"
+msgid "Notification: new user joined followed conference channel"
+msgstr "通知：フォロー中の会議チャンネルに新しいユーザーが参加しました"
+
+#: ../src/scenes/Sounds.rb:80
+msgctxt "Sounds"
+msgid "New user joined conference"
+msgstr "新しいユーザーが会議に参加しました"
+
+#: ../src/scenes/Sounds.rb:81
+msgctxt "Sounds"
+msgid "User left conference"
+msgstr "ユーザーが会議を退出しました"
+
+#: ../src/scenes/Sounds.rb:82
+msgctxt "Sounds"
+msgid "User knocking to the conference"
+msgstr "ユーザーが会議への参加をリクエストしています"
+
+#: ../src/scenes/Sounds.rb:83
+msgctxt "Sounds"
+msgid "New chat message"
+msgstr "新しいチャットメッセージ"
+
+#: ../src/scenes/Sounds.rb:84
+msgctxt "Sounds"
+msgid "Dice rolled in conference"
+msgstr "会議でサイコロが振られました"
+
+#: ../src/scenes/Sounds.rb:85
+msgctxt "Sounds"
+msgid "Card picked in conference"
+msgstr "会議でカードが引かれました"
+
+#: ../src/scenes/Sounds.rb:86
+msgctxt "Sounds"
+msgid "Card replaced in conference"
+msgstr "会議でカードが置き換えられました"
+
+#: ../src/scenes/Sounds.rb:87
+msgctxt "Sounds"
+msgid "Shuffled a deck in conference"
+msgstr "会議でデッキがシャッフルされました"
+
+#: ../src/scenes/Sounds.rb:88
+msgctxt "Sounds"
+msgid "Card placed in conference"
+msgstr "会議でカードが置かれました"
+
+#: ../src/scenes/Sounds.rb:89
+msgctxt "Sounds"
+msgid "Whisper in the conference"
+msgstr "会議でのささやき"
+
+#: ../src/scenes/Sounds.rb:90
+msgctxt "Sounds"
+msgid "Push To Talk enabled in conferences"
+msgstr "会議でプッシュ・トゥ・トークが有効になりました"
+
+#: ../src/scenes/Sounds.rb:91
+msgctxt "Sounds"
+msgid "Push To Talk disabled in conferences"
+msgstr "会議でプッシュ・トゥ・トークが無効になりました"
+
+#: ../src/scenes/Sounds.rb:92
+msgctxt "Sounds"
+msgid "Speech requested in conferences"
+msgstr "会議で発言がリクエストされました"
+
+#: ../src/scenes/Sounds.rb:93
+msgctxt "Sounds"
+msgid "Speech allowed in conferences"
+msgstr "会議で発言が許可されました"
+
+#: ../src/scenes/Sounds.rb:94
+msgctxt "Sounds"
+msgid "Speech denied in conferences"
+msgstr "会議で発言が拒否されました"
+
+#: ../src/scenes/Sounds.rb:95
+msgctxt "Sounds"
+msgid "Calling user"
+msgstr "ユーザーを呼び出し中"
+
+#: ../src/scenes/Sounds.rb:96
+msgctxt "Sounds"
+msgid "Incoming voice call"
+msgstr "着信音声通話"
+
+#: ../src/scenes/Sounds.rb:97
+msgctxt "Sounds"
+msgid "Recording started"
+msgstr "録音を開始しました"
+
+#: ../src/scenes/Sounds.rb:98
+msgctxt "Sounds"
+msgid "Recording stopped"
+msgstr "録音を停止しました"
+
+#: ../src/scenes/Sounds.rb:99
+msgctxt "Sounds"
+msgid "Only five seconds of recording left"
+msgstr "録音残り5秒"
+
+#: ../src/scenes/Sounds.rb:100
+msgctxt "Sounds"
+msgid "Error"
+msgstr "エラー"
+
+#: ../src/scenes/Sounds.rb:101
+msgctxt "Sounds"
+msgid "Clock sound"
+msgstr "時計の音"
+
+#: ../src/scenes/Sounds.rb:102
+msgctxt "Sounds"
+msgid "Alarm Sound"
+msgstr "アラーム音"
+
+#: ../src/scenes/Sounds.rb:103
+msgctxt "Sounds"
+msgid "Waiting for an action to be completed"
+msgstr "操作の完了を待っています"
+
+#: ../src/scenes/Sounds.rb:104
+msgctxt "Sounds"
+msgid "Signal"
+msgstr "信号音"
+
+#: ../src/scenes/Sounds.rb:111 ../src/scenes/Sounds.rb:177
+msgctxt "Sounds"
+msgid "Type name of the sound theme"
+msgstr "サウンドテーマの名前を入力"
+
+#: ../src/scenes/Sounds.rb:136
+msgctxt "Sounds"
+msgid "Sounds guide, press space to play"
+msgstr "サウンドガイド、再生するにはスペースキーを押してください"
+
+#: ../src/scenes/Sounds.rb:137
+msgctxt "Sounds"
+msgid "Editing sound theme %{theme}"
+msgstr "サウンドテーマ %{theme} を編集中"
+
+#: ../src/scenes/Sounds.rb:140
+msgctxt "Sounds"
+msgid "Play"
+msgstr "再生"
+
+#: ../src/scenes/Sounds.rb:141
+msgctxt "Sounds"
+msgid "Stop"
+msgstr "停止"
+
+#: ../src/scenes/Sounds.rb:142 ../src/scenes/Sounds.rb:236
+msgctxt "Sounds"
+msgid "Extract"
+msgstr "抽出"
+
+#: ../src/scenes/Sounds.rb:143
+msgctxt "Sounds"
+msgid "Change"
+msgstr "変更"
+
+#: ../src/scenes/Sounds.rb:144
+msgctxt "Sounds"
+msgid "Change sound theme name"
+msgstr "サウンドテーマの名前を変更"
+
+#: ../src/scenes/Sounds.rb:145
+msgctxt "Sounds"
+msgid "Save"
+msgstr "保存"
+
+#: ../src/scenes/Sounds.rb:146
+msgctxt "Sounds"
+msgid "Export"
+msgstr "エクスポート"
+
+#: ../src/scenes/Sounds.rb:147
+msgctxt "Sounds"
+msgid "Upload to server"
+msgstr "サーバーにアップロード"
+
+#: ../src/scenes/Sounds.rb:148
+msgctxt "Sounds"
+msgid "Close"
+msgstr "閉じる"
+
+#: ../src/scenes/Sounds.rb:187
+msgctxt "Sounds"
+msgid "Select new sound"
+msgstr "新しいサウンドを選択"
+
+#: ../src/scenes/Sounds.rb:194
+msgctxt "Sounds"
+msgid "The sound must not last longer than 5 minutes"
+msgstr "サウンドは5分以内でなければなりません"
+
+#: ../src/scenes/Sounds.rb:209
+msgctxt "Sounds"
+msgid "Where to save this theme"
+msgstr "このテーマの保存場所"
+
+#: ../src/scenes/Sounds.rb:222
+msgctxt "Sounds"
+msgid "Do you want to save this sound theme?"
+msgstr "このサウンドテーマを保存しますか？"
+
+#: ../src/scenes/Sounds.rb:234
+msgctxt "Sounds"
+msgid "File name"
+msgstr "ファイル名"
+
+#: ../src/scenes/Sounds.rb:235
+msgctxt "Sounds"
+msgid "Destination"
+msgstr "保存先"
+
+#: ../src/scenes/Sounds.rb:271
+msgctxt "Sounds"
+msgid "This sound theme contains unsaved changes. Do you want to upload it anyway?"
+msgstr "このサウンドテーマには未保存の変更があります。それでもアップロードしますか？"
+
+#: ../src/scenes/Sounds.rb:276
+msgctxt "Sounds"
+msgid "Sound theme ID. This ID will be used to track updates of this sound theme. Keep the current ID if you want to update existing sound theme."
+msgstr "サウンドテーマID。このIDはサウンドテーマの更新を追跡するために使用されます。既存のサウンドテーマを更新したい場合は現在のIDを保持してください。"
+
+#: ../src/scenes/Sounds.rb:300 ../src/scenes/Sounds.rb:308
+msgctxt "Sounds"
+msgid "Sound theme with that ID already exists."
+msgstr "そのIDのサウンドテーマは既に存在します。"
+
+#: ../src/scenes/Sounds.rb:327
+msgctxt "Sounds"
+msgid "Uploaded"
+msgstr "アップロードされました"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Forum structure (uncompressed)"
+msgstr "フォーラム構造（非圧縮）"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Session refresh"
+msgstr "セッションの更新"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "What's new"
+msgstr "新着情報"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Unit to test"
+msgstr "テストするユニット"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Forum structure (compressed)"
+msgstr "フォーラム構造（圧縮）"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Messages recipients"
+msgstr "メッセージの受信者"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Number of attempts to perform"
+msgstr "実行する試行回数"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Start"
+msgstr "開始"
+
+#: ../src/scenes/SpeedTest.rb:9
+msgctxt "SpeedTest"
+msgid "Blogs list"
+msgstr "ブログ一覧"
+
+#: ../src/scenes/SpeedTest.rb:33
+msgctxt "SpeedTest"
+msgid "Performing test, please wait"
+msgstr "テストを実行中です。お待ちください"
+
+#: ../src/scenes/SpeedTest.rb:48
+msgctxt "SpeedTest"
+msgid "Average time"
+msgstr "平均時間"
+
+#: ../src/scenes/SpeedTest.rb:49
+msgctxt "SpeedTest"
+msgid "Minimum time"
+msgstr "最短時間"
+
+#: ../src/scenes/SpeedTest.rb:50
+msgctxt "SpeedTest"
+msgid "Maximum time"
+msgstr "最長時間"
+
+#: ../src/scenes/SpeedTest.rb:51
+msgctxt "SpeedTest"
+msgid "Errors count"
+msgstr "エラー数"
+
+#: ../src/scenes/SpeedTest.rb:57
+msgctxt "SpeedTest"
+msgid "Test results"
+msgstr "テスト結果"
+
+#: ../src/scenes/Update.rb:13
+msgctxt "Update"
+msgid "A new version of this program is available. Do you want to download and instal it?"
+msgstr "このプログラムの新しいバージョンがあります。ダウンロードしてインストールしますか？"
+
+#: ../src/scenes/Update.rb:36 ../src/scenes/Update.rb:66 ../src/scenes/Update.rb:68
+msgctxt "Update"
+msgid "Please wait while files are downloaded."
+msgstr "ファイルをダウンロードしています。お待ちください。"
+
+#: ../src/scenes/Update.rb:40
+msgctxt "Update"
+msgid "The update has been downloaded. To install it, the program must be restarted.  Press enter to continue or escape to cancel."
+msgstr "アップデートがダウンロードされました。インストールするにはプログラムを再起動する必要があります。続行するにはEnterキーを、キャンセルするにはEscapeキーを押してください。"
+
+#: ../src/scenes/Update.rb:53
+msgctxt "Update"
+msgid "Now, the update will be installed. The program will restart."
+msgstr "これからアップデートをインストールします。プログラムが再起動します。"
+
+#: ../src/scenes/Update.rb:71
+msgctxt "Update"
+msgid "The program will be now reverted to the latest stable version. Elten will restart.  It may take several minutes."
+msgstr "プログラムは最新の安定版に戻ります。エルテンが再起動します。数分かかる場合があります。"
+
+#: ../src/scenes/UserSearch.rb:11
+msgctxt "UserSearch"
+msgid "Search users"
+msgstr "ユーザーを検索"
+
+#: ../src/scenes/UserSearch.rb:25
+msgctxt "UserSearch"
+msgid "No match found."
+msgstr "一致するものが見つかりませんでした。"
+
+#: ../src/scenes/UserSearch.rb:36
+msgctxt "UserSearch"
+msgid "Found items"
+msgstr "見つかった項目"
+
+#: ../src/scenes/UserSearch.rb:48
+msgctxt "UserSearch"
+msgid "Search again"
+msgstr "再検索"
+
+#: ../src/scenes/Users.rb:38
+msgctxt "Users"
+msgid "List of users"
+msgstr "ユーザーのリスト"
+
+#: ../src/scenes/UsersAddedMeToContacts.rb:13
+msgid "UsersAddedMeToThis section is unavailable for guests"
+msgstr "このセクションはゲストには利用できません"
+
+#: ../src/scenes/UsersAddedMeToContacts.rb:35
+msgctxt "UsersAddedMeToContacts"
+msgid "Users who added me to their contacts list"
+msgstr "私を連絡先リストに追加したユーザー"
+
+#: ../src/scenes/Users_RecentlyActived.rb:22
+msgctxt "Users_RecentlyActived"
+msgid "Recently active users"
+msgstr "最近アクティブなユーザー"
+
+#: ../src/scenes/Users_RecentlyRegistered.rb:22
+msgctxt "Users_RecentlyRegistered"
+msgid "Recently registered users"
+msgstr "最近登録したユーザー"
+
+#: ../src/scenes/WhatsNew.rb:43
+msgctxt "WhatsNew"
+msgid "What's new"
+msgstr "新着情報"
+
+#: ../src/scenes/WhatsNew.rb:54
+msgctxt "WhatsNew"
+msgid "New messages"
+msgstr "新しいメッセージ"
+
+#: ../src/scenes/WhatsNew.rb:55
+msgctxt "WhatsNew"
+msgid "New posts in followed threads"
+msgstr "フォロー中のスレッドの新しい投稿"
+
+#: ../src/scenes/WhatsNew.rb:56
+msgctxt "WhatsNew"
+msgid "New posts on the followed blogs"
+msgstr "フォロー中のブログの新しい投稿"
+
+#: ../src/scenes/WhatsNew.rb:57
+msgctxt "WhatsNew"
+msgid "New comments on your blog"
+msgstr "あなたのブログへの新しいコメント"
+
+#: ../src/scenes/WhatsNew.rb:58
+msgctxt "WhatsNew"
+msgid "New threads on followed forums"
+msgstr "フォロー中のフォーラムの新しいスレッド"
+
+#: ../src/scenes/WhatsNew.rb:59
+msgctxt "WhatsNew"
+msgid "New posts on followed forums"
+msgstr "フォロー中のフォーラムの新しい投稿"
+
+#: ../src/scenes/WhatsNew.rb:60
+msgctxt "WhatsNew"
+msgid "New friends"
+msgstr "新しい友達"
+
+#: ../src/scenes/WhatsNew.rb:61
+msgctxt "WhatsNew"
+msgid "Friends' birthday"
+msgstr "友達の誕生日"
+
+#: ../src/scenes/WhatsNew.rb:62
+msgctxt "WhatsNew"
+msgid "Mentions"
+msgstr "メンション"
+
+#: ../src/scenes/WhatsNew.rb:63
+msgctxt "WhatsNew"
+msgid "New comments to followed blog posts"
+msgstr "フォロー中のブログ投稿への新しいコメント"
+
+#: ../src/scenes/WhatsNew.rb:64
+msgctxt "WhatsNew"
+msgid "New blog followers"
+msgstr "ブログの新しいフォロワー"
+
+#: ../src/scenes/WhatsNew.rb:65
+msgctxt "WhatsNew"
+msgid "Blog mentions"
+msgstr "ブログのメンション"
+
+#: ../src/scenes/WhatsNew.rb:66
+msgctxt "WhatsNew"
+msgid "Awaiting group invitations"
+msgstr "保留中のグループ招待"
+
+#: ../src/scenes/WhatsNew.rb:67
+msgctxt "WhatsNew"
+msgid "Update available (%{version})"
+msgstr "利用可能な更新があります（%{version}）"
+
+#: ../src/scenes/WhatsNew.rb:83
+msgctxt "WhatsNew"
+msgid "There is nothing new."
+msgstr "新しいものはありません。"

--- a/locale/ja-JP/changelog/1_0.md
+++ b/locale/ja-JP/changelog/1_0.md
@@ -1,0 +1,1 @@
+The first release of Elten

--- a/locale/ja-JP/changelog/1_0_1.md
+++ b/locale/ja-JP/changelog/1_0_1.md
@@ -1,0 +1,1 @@
+- Fixed: reported issues

--- a/locale/ja-JP/changelog/1_0_2.md
+++ b/locale/ja-JP/changelog/1_0_2.md
@@ -1,0 +1,1 @@
+- Fixed: reported issues

--- a/locale/ja-JP/changelog/1_0_3.md
+++ b/locale/ja-JP/changelog/1_0_3.md
@@ -1,0 +1,8 @@
+- Added: statuses
+- Added: option to hide Elten to tray from "Exit" menu
+- Changed: new audio engine: FMOD
+- Changed: program interface
+- Fixed: blogs should now work correctly
+- Fixed: deleted GEM Seal that caused many issues
+- Fixed: keeping information about lines when sending data to server
+- Fixed: Some other bugs

--- a/locale/ja-JP/changelog/1_0_4.md
+++ b/locale/ja-JP/changelog/1_0_4.md
@@ -1,0 +1,9 @@
+- Added: users who added me to their contacts' list
+- Changed: a new engine to count forum posts
+- Changed: a new engine to read statuses
+- Changed: interface
+- Fixed: an error that caused word "LINE" to be read on every new line of text
+- Fixed: errors related to buffering of lines and characters in editboxes
+- Fixed: error that caused many characters to join into one in editboxes
+- Fixed: when Elten is unable to connect with Youtube, it will try to update Youtube-DL
+- Fixed: many errors causing hanging of the program, in such a cause Elten tries to reset current operation

--- a/locale/ja-JP/changelog/1_0_5.md
+++ b/locale/ja-JP/changelog/1_0_5.md
@@ -1,0 +1,13 @@
+- Added: buffers allowing users to write longer messages, posts and visitingcards
+- Fixed: program stability improvements
+- Changed: interface
+- Added: List of blogs
+- Added: error reporting
+- Added: language packs update along with program update, from next version
+- Fixed: rewrite of listboxes
+- Fixed: processing of characters ' and `
+- Fixed: user relogin on token expiration
+- Fixes: regexes in translations
+- Changed: listboxes are no longer circular
+- Added: an option to hide Elten in tray from menu under escape from main window
+- Changed: forum is a tree view now, remembering forum and thread position as well as enabling user to navigate using left and right arrows

--- a/locale/ja-JP/changelog/1_0_6.md
+++ b/locale/ja-JP/changelog/1_0_6.md
@@ -1,0 +1,9 @@
+- Fixed: stability improvements
+- Changed: new editboxes system
+- Changed: binary-data sending system
+- Changed: Winsock library implementation
+- Added: support for direct connection to servers
+- Added: support for direct HTTP queries
+- Added: support for direct buffering
+- Added: support of special events
+- Fixed: some minor bugs

--- a/locale/ja-JP/changelog/1_0_7.md
+++ b/locale/ja-JP/changelog/1_0_7.md
@@ -1,0 +1,1 @@
+- Fixed: some minor bug fixes

--- a/locale/ja-JP/changelog/1_0_8.md
+++ b/locale/ja-JP/changelog/1_0_8.md
@@ -1,0 +1,13 @@
+- Added: Possibility to select text in text fields by holding down the shift key and moving the cursor or whole text with CTRL+A
+- Added: Clipboard support through CTRL+X, CTRL+C and CTRL+V
+- Added: Possibility of autotranslating the selected text into the language selected in the program with CTRL+T
+- Fixed: errors occurring in text fields
+- Fixed: algorithm for creating new lines in text fields
+- Added: forms for posting blog posts, messages and forum posts
+- Changed: New messages interface
+- Added: Ability to select a contact when sending a message by pressing the up or down arrow in the "Receiver" field
+- Changed: interface
+- Fixed: Buffering of blog posts
+- Fixed: character conversion error in text fields
+- Fixed: reading of arrays in text fields
+- Fixed: sending of empty strings

--- a/locale/ja-JP/changelog/1_0_9.md
+++ b/locale/ja-JP/changelog/1_0_9.md
@@ -1,0 +1,6 @@
+- Changed: Forms declared by classes, not written manually with each implementation
+- Added: New sounds
+- Changed: interface
+- Added: Additional information in visitingcards
+- Changed: New data processing modules
+- Changed: Minor changes

--- a/locale/ja-JP/changelog/1_0_9_1.md
+++ b/locale/ja-JP/changelog/1_0_9_1.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_0_9_2.md
+++ b/locale/ja-JP/changelog/1_0_9_2.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_0_9_3.md
+++ b/locale/ja-JP/changelog/1_0_9_3.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_1.md
+++ b/locale/ja-JP/changelog/1_1.md
@@ -1,0 +1,24 @@
+- Changed: a different method of module processing and a different way of writing data, as well as new encryption methods
+- Changed: New "What's new" system
+- Changed: shortcuts
+- Added: list of keyboard shortcuts
+- Changed: List of users available for all users
+- Added: support for deleting categories and blog posts
+- Added: Preliminary version of media catalog
+- Added: New control: checkbox
+- Added: new menu category: "Tools"
+- Added: sound theme generator
+- Changed: New methods of data processing in "Files"
+- Changed: New way of adding programs: they are downloaded directly from the server at program start
+- Changed: elten.dll library updated to a new version with some improvements
+- Added: Automatic voice muting of screenreaders: NVDA, Jaws and WindowEyes
+- Added: Option "Admins" showing the list of program administrators
+- Changed: Significant changes in the forum, especially in the thread view
+- Changed: Improved error reporting system
+- Added: New interface settings allowing to change writing echoes, keyboard sensitivity, mute sounds, how selection lists are displayed and program start method
+- Added: Support for new events
+- Added: New sounds
+- Changed: Various smaller and larger changes in the interface and functions
+- Fixed: error with sending messages on chat
+- Fixed: error with duplicate letter information in some screenreader configurations
+- Fixed: error with text selection

--- a/locale/ja-JP/changelog/1_1_1.md
+++ b/locale/ja-JP/changelog/1_1_1.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_1_2.md
+++ b/locale/ja-JP/changelog/1_1_2.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_1_3.md
+++ b/locale/ja-JP/changelog/1_1_3.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_1_4.md
+++ b/locale/ja-JP/changelog/1_1_4.md
@@ -1,0 +1,3 @@
+- Changed: new encoding of data between client and server  in forum, messages, blogs, programs and media - the above functions will no longer work with older versions of Elten
+- Changed: updated Google Translate System
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_1_5.md
+++ b/locale/ja-JP/changelog/1_1_5.md
@@ -1,0 +1,5 @@
+- Added: new keyboard shortcuts on forum
+- Added: information about post position in thread
+- Changed: minor changes in the interface
+- Changed: new buffering method
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_1_6.md
+++ b/locale/ja-JP/changelog/1_1_6.md
@@ -1,0 +1,1 @@
+- Fixed: some reported bugs

--- a/locale/ja-JP/changelog/1_2.md
+++ b/locale/ja-JP/changelog/1_2.md
@@ -1,0 +1,7 @@
+- Added: Speedtest option
+- Added: HTTPS support for most connections
+- Changed: connections system
+- Added: updater in the menu
+- Added: changes in default settings
+- Added: rescue mode
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_2_1.md
+++ b/locale/ja-JP/changelog/1_2_1.md
@@ -1,0 +1,2 @@
+- Added: blog comments
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_2_2.md
+++ b/locale/ja-JP/changelog/1_2_2.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3.md
+++ b/locale/ja-JP/changelog/1_3.md
@@ -1,0 +1,12 @@
+- Added: brand new program agent responsible for maintaining the token and receiving server messages
+- Changed: ability to return from the tray using CTRL+ALT+SHIFT+E
+- Added: support for new shortcuts in text fields: page up, page down, ctrl+home and ctrl+end
+- Added: line wrapping
+- Changed: minor changes in the login system
+- Added: playlist
+- Added: sent messages
+- Added: Possibility to rename the blog and edit blog posts
+- Changed: More minor changes in the interface
+- Changed: New update and installation system
+- Changed: New program launch procedure
+- Fixed: reported errors

--- a/locale/ja-JP/changelog/1_3_1.md
+++ b/locale/ja-JP/changelog/1_3_1.md
@@ -1,0 +1,2 @@
+- Fixed: reported bugs
+- Changed: minor interface changes

--- a/locale/ja-JP/changelog/1_3_2.md
+++ b/locale/ja-JP/changelog/1_3_2.md
@@ -1,0 +1,7 @@
+- Fixed: reported bugs
+- Changed: new following threads check procedure in "What's new"
+- Changed: Translation API update
+- Added: new windows can now be opened without closing previous
+- Added: two new threads to load and save scenes
+- Changed: new editboxes initialization and focusing methods
+- Changed: thread loading system

--- a/locale/ja-JP/changelog/1_3_3.md
+++ b/locale/ja-JP/changelog/1_3_3.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_4.md
+++ b/locale/ja-JP/changelog/1_3_4.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_5.md
+++ b/locale/ja-JP/changelog/1_3_5.md
@@ -1,0 +1,3 @@
+- Changed: interface changes
+- Changed: new installer and updater
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_6.md
+++ b/locale/ja-JP/changelog/1_3_6.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_7.md
+++ b/locale/ja-JP/changelog/1_3_7.md
@@ -1,0 +1,5 @@
+- Changed: program launch procedure
+- Added: asynchronous operations support during speech
+- Added: undo and redo in editboxes
+- Changed: minor interface changes
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_8.md
+++ b/locale/ja-JP/changelog/1_3_8.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9.md
+++ b/locale/ja-JP/changelog/1_3_9.md
@@ -1,0 +1,3 @@
+- Added: EAPI projects compiler
+- Changed: minor interface changes
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9_1.md
+++ b/locale/ja-JP/changelog/1_3_9_1.md
@@ -1,0 +1,3 @@
+- Added: new audio processing method by player
+- Added: sliding of tracks
+- Fixed: media catalog

--- a/locale/ja-JP/changelog/1_3_9_2.md
+++ b/locale/ja-JP/changelog/1_3_9_2.md
@@ -1,0 +1,5 @@
+- Fixed: program agent
+- Added: alternate version of elten.dll compiled in Visual Studio
+- Changed: library version selection depends on computer capabilities
+- Added: new events processing
+- Changed: minor changes in the interface

--- a/locale/ja-JP/changelog/1_3_9_3.md
+++ b/locale/ja-JP/changelog/1_3_9_3.md
@@ -1,0 +1,2 @@
+- Added: Internet audio streaming and Internet radio support
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9_4.md
+++ b/locale/ja-JP/changelog/1_3_9_4.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9_5.md
+++ b/locale/ja-JP/changelog/1_3_9_5.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9_6.md
+++ b/locale/ja-JP/changelog/1_3_9_6.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9_7.md
+++ b/locale/ja-JP/changelog/1_3_9_7.md
@@ -1,0 +1,2 @@
+- Added: possibility to update to beta branch
+- Added: possibility to copy error information to clipboard

--- a/locale/ja-JP/changelog/1_3_9_8.md
+++ b/locale/ja-JP/changelog/1_3_9_8.md
@@ -1,0 +1,1 @@
+- Fixed: reported bugs

--- a/locale/ja-JP/changelog/1_3_9_9.md
+++ b/locale/ja-JP/changelog/1_3_9_9.md
@@ -1,0 +1,1 @@
+- Changed: changes enabling Elten to update to future 2.0 version

--- a/locale/ja-JP/changelog/1_3_9_9_1.md
+++ b/locale/ja-JP/changelog/1_3_9_9_1.md
@@ -1,0 +1,1 @@
+- Changed: buffers protocol update

--- a/locale/ja-JP/changelog/1_3_9_9_2.md
+++ b/locale/ja-JP/changelog/1_3_9_9_2.md
@@ -1,0 +1,1 @@
+- Fixed: processing of polish characters in system directory names

--- a/locale/ja-JP/changelog/1_3_9_9_3.md
+++ b/locale/ja-JP/changelog/1_3_9_9_3.md
@@ -1,0 +1,1 @@
+- Fixed: server communication system

--- a/locale/ja-JP/changelog/1_3_9_9_4.md
+++ b/locale/ja-JP/changelog/1_3_9_9_4.md
@@ -1,0 +1,1 @@
+- Fixed: processing of polish characters in usernames

--- a/locale/ja-JP/changelog/2_0.md
+++ b/locale/ja-JP/changelog/2_0.md
@@ -1,0 +1,38 @@
+- Added: avatars
+- Added: youtube support
+- Added: profiles
+- Added: Extended visitingcards
+- Changed: blog engine
+- Added: voice forum posts, blog posts and messages
+- Changed: division of forums
+- Added: forum search option
+- Added: shared files
+- Added: signatures
+- Added: Welcome message
+- Added: Extended file manager
+- Added: polls
+- Added: New settings
+- Added: New sounds
+- Added: German translation
+- Changed: Replaced file engine
+- Changed: Recirculated text field engine
+- Changed: Recirculated forum engine
+- Changed: New protocols for communication with the server
+- Added: New translator
+- Added: New media player
+- Changed: New Elten core construction
+- Added: New Elten API features
+- Changed: New update system
+- Changed: New agent
+- Changed: Changes in the interface
+- Added: Reset password
+- Added: honors
+- Fixed: Overall performance improvements
+- Fixed: capslock key processing
+- Fixed: operation of numeric keypad
+- Fixed: problems with Polish characters in file names
+- Fixed: problems with Polish characters in the user name
+- Fixed: error with losing the session when losing the Internet connection
+- Fixed: problem with closing Elten window in case of hangup
+- Fixed: instability when using Window Eyes
+- Fixed: window hangup when writing long texts

--- a/locale/ja-JP/changelog/2_0_1.md
+++ b/locale/ja-JP/changelog/2_0_1.md
@@ -1,0 +1,4 @@
+- Added: shortcut to open file or folder using explorer in files, CTRL+O
+- Fixed: error when minimizing to tray from menu
+- Fixed: error with deleting shared files
+- Added: holding down the arrow moves the cursor in repeat

--- a/locale/ja-JP/changelog/2_0_2.md
+++ b/locale/ja-JP/changelog/2_0_2.md
@@ -1,0 +1,13 @@
+- Fixed: error with playback of files containing double spaces in names
+- Fixed: error with playback of files containing many Polish characters in names
+- Added: keyboard shortcuts for copying, cutting and pasting files in files
+- Added: CTRL+D shortcut to check the contents of the folder in files
+- Added: CTRL+I shortcut for checking size in files
+- Added: option to create voice recordings in files
+- Changed: from now on it is possible to copy and move folders
+- Added: shortcuts to document, music and desktop folders in files
+- Added: possibility of audio conversion in files
+- Fixed: error with skipping some files by playlists
+- Fixed: error with the inability to update the program in case of enabled Elten autostart
+- Fixed: bug with opening multiple Elten instances when Elten autostart is enabled
+- Changed: from now on, all recordings are made in stereo as long as the sound card and microphone support this format.

--- a/locale/ja-JP/changelog/2_0_3.md
+++ b/locale/ja-JP/changelog/2_0_3.md
@@ -1,0 +1,2 @@
+- Added: ability to export files and text to audio files, supports only sapi
+- Added: CTRL+P shortcut in editboxes to export text to file

--- a/locale/ja-JP/changelog/2_0_3_1.md
+++ b/locale/ja-JP/changelog/2_0_3_1.md
@@ -1,0 +1,1 @@
+- Fixed: error when reading to a file with paragraph splitting or creating a single file

--- a/locale/ja-JP/changelog/2_0_4.md
+++ b/locale/ja-JP/changelog/2_0_4.md
@@ -1,0 +1,5 @@
+- Added: possibility to choose output format when downloading from YouTube
+- Added: new sounds
+- Changed: YouTube content is no longer cached
+- Fixed: Error preventing export of some files
+- Fixed: error that prevents Elten from starting in case of enabled autostart feature

--- a/locale/ja-JP/changelog/2_0_4_1.md
+++ b/locale/ja-JP/changelog/2_0_4_1.md
@@ -1,0 +1,3 @@
+- Added: progress bar in Youtube
+- Fixed: speech to file
+- Fixed: sounds in files

--- a/locale/ja-JP/changelog/2_0_4_2.md
+++ b/locale/ja-JP/changelog/2_0_4_2.md
@@ -1,0 +1,5 @@
+- Added: possibility to save voice posts and messages (CTRL+S)
+- Added: Ability to save avatars (during playback SHIFT+ENTER)
+- Fixed: speech to file
+- Fixed: playback error on youtube
+- Fixed: bug that makes it impossible to run the program when installing the version above 2.0

--- a/locale/ja-JP/changelog/2_0_4_3.md
+++ b/locale/ja-JP/changelog/2_0_4_3.md
@@ -1,0 +1,3 @@
+- Fixed: Playing videos from Youtube
+- Fixed: downloading files from youtube
+- Fixed: saving speech to file

--- a/locale/ja-JP/changelog/2_1.md
+++ b/locale/ja-JP/changelog/2_1.md
@@ -1,0 +1,20 @@
+- Added: support for sending and receiving e-mails (each user has received an e-mail address "login@elten-net.eu" to which any person can send messages received on Elten, as well as which will be given as the sender's address when sending e-mails outside
+- Added: possibility to send attachments (up to three in one message, maximum 16MB per attachment) (applies to both private messages and emails)
+- Changed: Google Translate support restored, which will be the preferred translator if not available, Elten will try to use the Yandex translator
+- Added: option to unpack and pack files (supported formats: zip, rar, 7zip)
+- Changed: update system
+- Added: progress bars for downloading larger files
+- Added: support for new audio formats
+- Added: clocks and alarms
+- Added: new settings
+- Added: searching text fields under CTRL+F
+- Changed: the structure of the settings
+- Changed: grouping items in the Community menu
+- Changed: the short for quoting posts is now CTRL+D
+- Changed: there are several options for managing the playlist in the main window below the tab
+- Added: information on who is online, on user lists
+- Added: possibility to scroll through voice posts with f4 key
+- Added: possibility to open program menu from any place with SHIFT+F2 combination
+- Fixed: problem with playing YouTube on older systems
+- Fixed: bug with cancelling speech when reading notifications
+- Fixed: shortcuts in the menu

--- a/locale/ja-JP/changelog/2_1_1.md
+++ b/locale/ja-JP/changelog/2_1_1.md
@@ -1,0 +1,4 @@
+- Added: possibility to export portable version to one exe file (SFX) (loss of the ability to save settings)
+- Added: from the menu under alt key in shared files one can copy a link to a specific file, which can then be used for example in a web browser
+- Changed: from now on, banned users can log in, but cannot post on the forum or use the chat
+- Changed: ban management system

--- a/locale/ja-JP/changelog/2_1_2.md
+++ b/locale/ja-JP/changelog/2_1_2.md
@@ -1,0 +1,8 @@
+- Added: Elten APi now includes a tree view as a programmable control
+- Changed: menu appearance in the file manager
+- Fixed: error when trying to open an empty folder in files
+- Fixed: errors related to translations
+- Fixed: Occasional bug in loading the results list on YouTube
+- Fixed: it is no longer possible to send folders to the server, previously this was also impossible, but the option was available in the menu causing errors
+- Fixed: from now on, folders with files containing Polish characters are removed correctly
+- Fixed: cutting out folders already works like moving, not copying anymore

--- a/locale/ja-JP/changelog/2_1_3.md
+++ b/locale/ja-JP/changelog/2_1_3.md
@@ -1,0 +1,6 @@
+- Added: Guest account
+- Added: searching for users
+- Added: recently active users
+- Added: recently registered users
+- Changed: from now on, when sending messages and adding contacts, the program does not inform about the non-existence of a given user when there is a mismatch in the login
+- Fixed: closing the menu in shared files opened the file removal dialog

--- a/locale/ja-JP/changelog/2_1_4.md
+++ b/locale/ja-JP/changelog/2_1_4.md
@@ -1,0 +1,13 @@
+- Added: possibility of browsing and reading to file of documents in doc, pdf, epub, mobi, html, rtf formats
+- Added: debugging mode
+- Added: list of keyboard shortcuts under F1
+- Added: possibility to quickly switch speech output to the screen reader with SHIFT+F1
+- Added: new sounds
+- Changed: updated Elten API library (elten.dll)
+- Changed: menu in shared files
+- Removed: unused libraries and dependencies
+- Fixed: bug preventing editing some txt files
+- Fixed: menu in shared files opens normally
+- Fixed: problem that prevented connection to the server on some configurations
+- Fixed: error allowing to open menu in menu
+- Fixed: code optimization

--- a/locale/ja-JP/changelog/2_1_5.md
+++ b/locale/ja-JP/changelog/2_1_5.md
@@ -1,0 +1,7 @@
+- Added: CTRL+D on the sound file gives its length
+- Added: Space on Youtube search result gives its length
+- Changed: new, faster procedure for searching audio files
+- Fixed: reading to a file from the file manager should now work correctly
+- Fixed: it is possible to select the screen reader operation from the main window
+- Fixed: the file manager no longer hangs in folders containing a lot of files
+- Fixed: minor fixes of reading information on forum

--- a/locale/ja-JP/changelog/2_1_6.md
+++ b/locale/ja-JP/changelog/2_1_6.md
@@ -1,0 +1,2 @@
+- Fixed: stability improvements
+- Changed: server connection protocol

--- a/locale/ja-JP/changelog/2_1_7.md
+++ b/locale/ja-JP/changelog/2_1_7.md
@@ -1,0 +1,1 @@
+- Fixed: redirection support

--- a/locale/ja-JP/changelog/2_1_8.md
+++ b/locale/ja-JP/changelog/2_1_8.md
@@ -1,0 +1,5 @@
+- Fixed: server connection protocol
+- Changed: changes to improve the smooth running
+- Changed: login system updated to Elten 2.2 beta branch version
+- Changed: agent updated to Elten 2.2 beta branch (excluding new notifications)
+- Changed: update of external libraries to the latest version as of January 1, 2018

--- a/locale/ja-JP/changelog/2_1_8_1.md
+++ b/locale/ja-JP/changelog/2_1_8_1.md
@@ -1,0 +1,2 @@
+- Fixed: login system
+- Fixed: error causing a critical interruption of an agent's work when the connection to the server is interrupted

--- a/locale/ja-JP/changelog/2_2.md
+++ b/locale/ja-JP/changelog/2_2.md
@@ -1,0 +1,19 @@
+- Changed: brand new audio engine supporting more formats
+- Changed: rewritten forum and message processing interfaces
+- Changed: rewritten keyboard system
+- Changed: menu interface
+- Added: mentions
+- Added: settings of what's new
+- Added: new elements of what's new: new posts and threads in the followed forums, friends' birthdays, mentions and friendships
+- Added: Tracked forums
+- Added: possibility of hiding blog entries from unlogged users and editing audio entries
+- Changed: update of the login system
+- Added: management of autologin keys
+- Added: new shortcuts in the file player
+- Fixed: error with displaying some folders in files and playing some files
+- Added: details on Youtube under tab key
+- Added: black list
+- Fixed: problem with playback of some file formats
+- Fixed: problems with program stability
+- Fixed: long loading time for language packages
+- Changed: new password reset procedure

--- a/locale/ja-JP/changelog/2_2_1.md
+++ b/locale/ja-JP/changelog/2_2_1.md
@@ -1,0 +1,5 @@
+- Fixed: problem with opening menu in messages with empty inbox
+- Fixed: problem that makes it impossible to edit the first blog post
+- Fixed: problem with the autologin turning off
+- Fixed: problem with loading cursor in editboxes
+- Fixed: documents in the help menu should already display correctly

--- a/locale/ja-JP/changelog/2_2_2.md
+++ b/locale/ja-JP/changelog/2_2_2.md
@@ -1,0 +1,6 @@
+- Changed: rewritten the editbox system from scratch
+- Changed: midi file playback support
+- Fixed: bug preventing changing of privacy settings when creating audio post on a blog
+- Fixed: Bug causing the sending of logout notifications in the chat even when the chat was not open
+- Added: sound marking of forums containing unread posts
+- Added: possibility to mark the forum as read

--- a/locale/ja-JP/changelog/2_2_2_1.md
+++ b/locale/ja-JP/changelog/2_2_2_1.md
@@ -1,0 +1,4 @@
+- Fixed: the menu on the empty list of followed forums is now working correctly
+- Fixed: when pressing ALT+F4 the volume of the sound theme is no longer reset
+- Fixed: from now on, pressing a letter in the file list of an empty folder does not cause an error
+- Changed: when creating new files and folders, the default name is not entered in the name field

--- a/locale/ja-JP/changelog/2_2_2_2.md
+++ b/locale/ja-JP/changelog/2_2_2_2.md
@@ -1,0 +1,5 @@
+- Fixed: in single-line text fields long lines are no longer wrapped up
+- Fixed: no more letters can be entered in the numerical fields
+- Fixed: Elten API scripts work correctly
+- Added: possibility to disable line wrapping
+- Added: possibility to mark all blog posts as read

--- a/locale/ja-JP/changelog/2_2_2_3.md
+++ b/locale/ja-JP/changelog/2_2_2_3.md
@@ -1,0 +1,2 @@
+- Fixed: downloading previously cached videos to Youtube no longer causes a critical exception
+- Changed: saving of version information updated

--- a/locale/ja-JP/changelog/2_2_2_4.md
+++ b/locale/ja-JP/changelog/2_2_2_4.md
@@ -1,0 +1,2 @@
+- Fixed: opening the menu on the item "load more messages" no longer causes a critical error
+- Fixed: the background in the dialog windows respects the volume of the sound theme

--- a/locale/ja-JP/changelog/2_2_3.md
+++ b/locale/ja-JP/changelog/2_2_3.md
@@ -1,0 +1,11 @@
+- Added: new format for audio conversion - opus
+- Added: OPUS, AAC and WMA streaming is now supported for playback of shared files
+- Changed: from now on, voice threads have text titles
+- Changed: the search of text fields is not case sensitive
+- Changed: the range of frequency changes during media playback was increased
+- Fixed: opening the user menu from the blog list no longer causes a critical error
+- Fixed: closing the stream recording dialog does not close the whole context
+- Fixed: when playing voice entries with the F4 key, the text content is processed correctly
+- Fixed: the menu on the blog list should no longer cause critical exceptions when opening a blog
+- Fixed: pressing the enter key on an empty list of shared files no longer causes an error
+- Fixed: after pressing delete key on another user's blog there was a question about deleting an post, after confirmation Elten called up a critical exception

--- a/locale/ja-JP/changelog/2_2_4.md
+++ b/locale/ja-JP/changelog/2_2_4.md
@@ -1,0 +1,5 @@
+- Changed: from now on, the audio on the server is saved in OPUS format
+- Changed: maximum length of blog posts from now on is one hour
+- Changed: update of the codec library to the latest version as of April 29, 2018
+- Fixed: scrolling text by holding down the left arrow works correctly now
+- Fixed: better support for OPUS codec streaming

--- a/locale/ja-JP/changelog/2_2_4_1.md
+++ b/locale/ja-JP/changelog/2_2_4_1.md
@@ -1,0 +1,1 @@
+- Fixed: better audio streaming support

--- a/locale/ja-JP/changelog/2_2_4_2.md
+++ b/locale/ja-JP/changelog/2_2_4_2.md
@@ -1,0 +1,1 @@
+- Fixed: 64-bit codec versions were accidentally added to the previous compilation, which made it impossible to send audio to the server from computers with 32-bit operating systems installed

--- a/locale/ja-JP/changelog/2_2_4_3.md
+++ b/locale/ja-JP/changelog/2_2_4_3.md
@@ -1,0 +1,1 @@
+- Fixed: better support of audio streaming with slower Internet connection

--- a/locale/ja-JP/changelog/2_2_5.md
+++ b/locale/ja-JP/changelog/2_2_5.md
@@ -1,0 +1,4 @@
+- Added: possibility for moderators to move posts
+- Fixed: lines are now correctly wrapped in longer text fields
+- Fixed: note editing should work correctly
+- Changed: opus codec library updated to the latest version

--- a/locale/ja-JP/changelog/2_2_6.md
+++ b/locale/ja-JP/changelog/2_2_6.md
@@ -1,0 +1,4 @@
+- Fixed: the page up and page down keys in editboxes are now working correctly
+- Fixed: when searching for texts in editboxes, the escape key works correctly
+- Fixed: on the main tab of the forum the menu works correctly now
+- Fixed: Polish diacritics are correctly read in the speech synthesizer selection list

--- a/locale/ja-JP/changelog/2_2_7.md
+++ b/locale/ja-JP/changelog/2_2_7.md
@@ -1,0 +1,6 @@
+- Fixed: problem with empty "what's new" when an update is available in the beta branch
+- Fixed: the agent reads the beta configuration correctly
+- Changed: updating libraries to the latest on July 24, 2018
+- Changed: already redundant libraries have been removed
+- Added: Ignore new tags in text fields for compatibility with future versions of Elten
+- Fixed: information for unsupported characters added during registration

--- a/locale/ja-JP/changelog/2_2_7_1.md
+++ b/locale/ja-JP/changelog/2_2_7_1.md
@@ -1,0 +1,2 @@
+- Fixed: the old agent version was added to the previous release by mistake
+- Fixed: the update system correctly recognizes new stable releases when a beta branch is available

--- a/locale/ja-JP/changelog/2_2_8.md
+++ b/locale/ja-JP/changelog/2_2_8.md
@@ -1,0 +1,1 @@
+- Added: support for two-factor authentication (SMS)

--- a/locale/ja-JP/changelog/2_2_8_1.md
+++ b/locale/ja-JP/changelog/2_2_8_1.md
@@ -1,0 +1,1 @@
+- Changed: Update of Youtube support

--- a/locale/ja-JP/changelog/2_2_8_2.md
+++ b/locale/ja-JP/changelog/2_2_8_2.md
@@ -1,0 +1,1 @@
+- Changed: Update of Youtube support

--- a/locale/ja-JP/changelog/2_2_8_3.md
+++ b/locale/ja-JP/changelog/2_2_8_3.md
@@ -1,0 +1,1 @@
+- Fixed: problem that Elten didn't close the file handles when analyzing them, which made it impossible to edit files, for example attached messages, until the program was closed

--- a/locale/ja-JP/changelog/2_2_8_4.md
+++ b/locale/ja-JP/changelog/2_2_8_4.md
@@ -1,0 +1,2 @@
+- Changed: Youtube-DL update
+- Fixed: support for upgrading to beta

--- a/locale/ja-JP/changelog/2_2_8_5.md
+++ b/locale/ja-JP/changelog/2_2_8_5.md
@@ -1,0 +1,1 @@
+- Changed: update of server connection protocols

--- a/locale/ja-JP/changelog/2_3.md
+++ b/locale/ja-JP/changelog/2_3.md
@@ -1,0 +1,20 @@
+- Added: groups
+- Added: five new languages: Spanish, French, Croatian, Portuguese and Russian
+- Added: possibility to attach files and polls on the forum
+- Added: new moderator tools
+- Added: on blogs, links to Youtube are automatically detected and can be played back from the program level
+- Added: support for unicode
+- Removed: Media catalog
+- Removed: Elten API Compiler
+- Changed: translations now use a key system instead of a dictionary
+- Changed: messages are now displayed by recipients and topics and automatically refreshed
+- Changed: notifications now contain detailed information and differ in sound depending on the reason that caused them
+- Changed: new main menu layout
+- Changed: minor interface changes
+- Changed: the program agent was rewritten
+- Changed: HTTP version 2.0 is now used in communication with the server.
+- Changed: new client authentication method
+- Changed: updated libraries
+- Fixed: the translation no longer affects the text to be entered
+- Fixed: In case of a communication problem with Elten server, it no longer hangs out
+- Fixed: JSON is parsed correctly now

--- a/locale/ja-JP/changelog/2_3_1.md
+++ b/locale/ja-JP/changelog/2_3_1.md
@@ -1,0 +1,16 @@
+- Added: list of recently created groups
+- Added: possibility to choose a sound card
+- Changed: the Calibre library is now used for reading books.
+- Changed: new link test interface
+- Fixed: the list of sound themes to download is now displayed correctly
+- Fixed: it is again possible to quote posts
+- Fixed: Elten reads information about available updates correctly
+- Fixed: the agent does not return an exception when the notification sound cannot be played
+- Fixed: Reading to file is now working correctly
+- Fixed: the main column selected on the lists in the forum tab is remembered
+- Fixed: the menu processes the shortcuts correctly when the keys are pressed quickly
+- Fixed: Elten no longer switches to English by default after updating when no language has been selected previously
+- Fixed: the forum descriptions are read correctly
+- Fixed: the cursor no longer jumps to empty columns when navigating tables
+- Fixed: What's new closes again when there are no more pending events
+- Changed: Unification of audio handling

--- a/locale/ja-JP/changelog/2_3_2.md
+++ b/locale/ja-JP/changelog/2_3_2.md
@@ -1,0 +1,8 @@
+- Added: possibility to choose a microphone
+- Changed: new window with information about the program version
+- Changed: from now on, the recorded sounds are encoded on the fly to the Opus format.
+- Changed: loading a forum requires fewer queries to the server
+- Changed: updated libraries
+- Fixed: pressing the enter while writing the first blog comment no longer causes a critical exception
+- Fixed: the display of older messages is now working correctly
+- Fixed: support of queuing of queries to the server

--- a/locale/ja-JP/changelog/2_3_3.md
+++ b/locale/ja-JP/changelog/2_3_3.md
@@ -1,0 +1,3 @@
+- Added: list of threads and groups popular among friends
+- Added: list of blogs popular among friends
+- Added: possibility to disable comments under specific blog posts

--- a/locale/ja-JP/changelog/2_3_4.md
+++ b/locale/ja-JP/changelog/2_3_4.md
@@ -1,0 +1,12 @@
+- Added: possibility to change the type of blog post
+- Added: Login history
+- Added: possibility to set up reporting of changes in the account and unknown logins via e-mails
+- Added: possibility to browse the list of people following our blog
+- Added: possibility to create blogs shared with other users
+- Added: list of moderated groups
+- Changed: from now on, the visitingcard, signature and status are set in a profile edit
+- Changed: new user location selection system
+- Changed: next interface elements are tables
+- Fixed: switching the sound card with the sound theme turned off
+- Fixed: detection of the default microphone
+- Removed: shared files

--- a/locale/ja-JP/changelog/2_3_4_1.md
+++ b/locale/ja-JP/changelog/2_3_4_1.md
@@ -1,0 +1,2 @@
+- Added: possibility to transfer posts between blogs
+- Fixed: menu on blog list

--- a/locale/ja-JP/changelog/2_3_4_2.md
+++ b/locale/ja-JP/changelog/2_3_4_2.md
@@ -1,0 +1,2 @@
+- Added: ability to pin threads
+- Added (experimentally): in the lists, the F4 key gives the number of the selected item and the size of the list

--- a/locale/ja-JP/changelog/2_3_5.md
+++ b/locale/ja-JP/changelog/2_3_5.md
@@ -1,0 +1,8 @@
+- Added: possibility to encrypt the automatic login key
+- Added: delete comments on blog
+- Added: (experimental and preliminary) group conversations
+- Added: support for text scrolling while reading (SAPI5 only)
+- Changed: new default sound theme prepared by user daszekmdn
+- Fixed: voice messaging
+- Fixed: Elten does not provide update information when it fails to connect to the server
+- Fixed: queuing of queries

--- a/locale/ja-JP/changelog/2_3_6.md
+++ b/locale/ja-JP/changelog/2_3_6.md
@@ -1,0 +1,1 @@
+- Changed: new honors system

--- a/locale/ja-JP/changelog/2_3_6_1.md
+++ b/locale/ja-JP/changelog/2_3_6_1.md
@@ -1,0 +1,3 @@
+- Fixed: Looped acceptance of regulations with Polish characters in Windows user name
+- Fixed: displaying the conversation in What's new
+- Fixed: marking new messages in conversations

--- a/locale/ja-JP/changelog/2_3_7.md
+++ b/locale/ja-JP/changelog/2_3_7.md
@@ -1,0 +1,4 @@
+- Added: possibility to change the blog language
+- Changed: new, temporary (until version 2.4 is released) Youtube engine
+- Changed: the list of new comments on blogs now shows all blogs
+- Changed: Opening a blog from the user menu shows all blogs of specific user

--- a/locale/ja-JP/changelog/2_3_8.md
+++ b/locale/ja-JP/changelog/2_3_8.md
@@ -1,0 +1,5 @@
+- Changed: groups are now sorted by date of last post
+- Changed: language selection when creating polls
+- Fixed: sound muting
+- Fixed: Google Translator support
+- Fixed: Youtube support, further updates may be required

--- a/locale/ja-JP/changelog/2_4.md
+++ b/locale/ja-JP/changelog/2_4.md
@@ -1,0 +1,53 @@
+- Added: sound guide and editing of sound themes
+- Added: possibility to exclude information on types of controls
+- Added: possibility to jump by tags
+- Added: possibility of changing the playback speed
+- Added: NVDA addon providing support for text scrolling and Braille displays
+- Added: log viewer
+- Added: Filtering of responses in polls
+- Added: thread marking
+- Added: bookmarks in threads
+- Added: possibility to browse all threads in the group
+- Added: possibility to choose how to sort the forum tree
+- Added: blog settings
+- Added: closed forums
+- Added: Pre-defined tags in the forums
+- Added: possibility to edit group conversations
+- Added: possibility to change the name and unsubscribe from the notes
+- Added: quick actions
+- Added: Do not disturb mode and possibility to mute the conversation
+- Added: audible representation of letters and menus
+- Added: alternative login codes
+- Added: group regulations
+- Added: Mixed forums
+- Added: liking of forum entries
+- Added: spelling check
+- Added: Language filters
+- Added: settings of user permissions in groups
+- Added: history of mentions
+- Added: Replies to mentions
+- Added: mentions and following of blog entries
+- Added: Conferences
+- Added: Calling users
+- Added: premium packages
+- Changed: new administrators window
+- Changed: new settings, account and group configuration windows
+- changed: New menu layout, window-dependent options moved to context menu
+- Changed: unification of player and media fields
+- Changed: new forum search engine
+- Changed: new keyboard operation
+- Changed: rewritten handling of SAPI
+- Changed: system storage operation integrated with Elten
+- Changed: new recording window
+- Changed: Elten integrated audio codecs (Vorbis and Opus)
+- Changed: new translation format
+- Changed: new location and setting format
+- Changed: unification of the code responsible for server queries
+- Changed: new APIs for programs
+- Changed: libraries update
+- Fixed: unicode operation in some functions
+- Removed: youtube (moved to a separate program)
+- Removed: files (moved to a separate program)
+- Removed: playlist (moved to a separate program)
+- Removed: avatars
+- Removed: chat

--- a/locale/ja-JP/changelog/2_4_0_1.md
+++ b/locale/ja-JP/changelog/2_4_0_1.md
@@ -1,0 +1,8 @@
+- Changed: Vorbis conversion quality for soundthemes is now 128kbps by default
+- Fixed: Elten no longer crashes when trying to edit forum settings just after leaving a thread
+- Fixed: option to hide signatures is no longer visible when courier package is not active, previously it was displayed, but did nothing
+- Fixed: Dependency load order was modified to prevent crash when safe DLL searching is disabled in system
+- Fixed: Elten should no longer crash when trying to reset password
+- Fixed: Elten should not crash when a soundtheme is missing background sounds
+- Fixed: navigating the blog list should no longer cause hang-ups
+- Fixed: Elten does not crash after trying to export newly created soundtheme

--- a/locale/ja-JP/changelog/2_4_0_2.md
+++ b/locale/ja-JP/changelog/2_4_0_2.md
@@ -1,0 +1,6 @@
+- Added: ability to process characters by voice or screen reader
+- Changed: Braille support is now disabled by default
+- Fixed: The conference window automatically closes when a conference is not active
+- Fixed: Spellcheck should no longer crash the program
+- Fixed: When downloading attachments, Elten again asks to overwrite the file
+- Fixed: repeating dependencies could cause problems with some hardware configurations

--- a/locale/ja-JP/changelog/2_4_0_3.md
+++ b/locale/ja-JP/changelog/2_4_0_3.md
@@ -1,0 +1,3 @@
+- Changed: from now on channels in conferences are sorted by number of users
+- Fixed: messages should no longer hang up while typing a reply when receiving a new message
+- Fixed: closing the window of choosing a poll to join should no longer cause an error in messages

--- a/locale/ja-JP/changelog/2_4_1.md
+++ b/locale/ja-JP/changelog/2_4_1.md
@@ -1,0 +1,18 @@
+- Added: new translation - Romanian (thanks to user StormProductions)
+- Added: information about missed calls
+- Added: call history
+- Added: ability to perform dice rolls and card games in conferences
+- Added: new quick actions to manipulate conferences
+- Added: ability to view all messages exchanged with a user
+- Added: ability to ban and kick users from channels
+- Added: ability to appoint more channel administrators
+- Added: redirection of output sound card in conferences
+- Added: ability to check position and channel size
+- Changed: Ruby updated to version 3.0
+- Changed: optimizations related to forum handling
+- Changed: Conference window rebuilt
+- Changed: mixed conference recording now doesn't contain whispers directed by us or to us
+- Fixed: it is again possible to disable listening from the streamed sound card
+- Fixed: possibility to change welcome message restored
+- Fixed: for some blogs it was not possible to display editors list
+- Fixed: proper display of chat history after hiding conference window

--- a/locale/ja-JP/changelog/2_4_1_1.md
+++ b/locale/ja-JP/changelog/2_4_1_1.md
@@ -1,0 +1,4 @@
+- Added: channel quality can be selected from several presets, also custom quality can be selected,
+- Changed: new encoder settings selectable when creating and editing a channel,
+- Fixed: better support for 2.5 and 5 ms Opus frames,
+- Fixed: better support for link problems in conferences.

--- a/locale/ja-JP/changelog/2_4_1_2.md
+++ b/locale/ja-JP/changelog/2_4_1_2.md
@@ -1,0 +1,1 @@
+- Fixed: changes to the NVDA add-on for compatibility with the upcoming 2021.1 release

--- a/locale/ja-JP/changelog/2_4_1_3.md
+++ b/locale/ja-JP/changelog/2_4_1_3.md
@@ -1,0 +1,1 @@
+- Changed: updated list of payment methods available when purchasing premium packages

--- a/locale/ja-JP/changelog/2_4_2.md
+++ b/locale/ja-JP/changelog/2_4_2.md
@@ -1,0 +1,19 @@
+- Added: invisible interface
+- Added: feeds
+- Added: ability to rotate in conferences
+- Added: ability to create channels with waiting room in conferences
+- Added: ability to create permanent channels in conferences
+- Added: new window with summary of reported forum posts
+- Added: ability to invite users to conferences
+- Added: ability to set channel message of the day in conferences
+- Added: option to set Elten to automatically mute microphone in a conference while recording other voice content
+- Changed: from now on, when soundtheme is turned off, some information previously signaled only by sound will be announced by speech
+- Changed: now activity reports sent to server contain more information about Elten configuration
+- Changed: from now on voice calls take place in conference window
+- Changed: some text fields now have content selected by default
+- Changed: new tab in What's New informing about pending invitations to groups
+- Fixed: from now on it is possible to enter characters that require pressing a specific key sequence
+- Fixed: when changing forums during creating a new topic there could be an error causing the loss of content
+- Fixed: when closing Elten, the Ruby process should now properly close even if an error occurred
+- Fixed: some sound files were not being properly encoded into OGG Vorbis format, which could cause problems when creating sound themes
+- Fixed: when sound theme was disabled, the incoming call sound was also muted

--- a/locale/ja-JP/changelog/2_4_2_1.md
+++ b/locale/ja-JP/changelog/2_4_2_1.md
@@ -1,0 +1,6 @@
+- Added: possibility to move by chapters when playing audio
+- Added: information about played audio file
+- Added: option to redirect browsers visiting blog to another blog
+- Added: possibility to edit excerpts of blog posts
+- Changed: now it is possible to put text in audio posts on blogs
+- Changed: NVDA addon updated to support NVDA version 2021.1

--- a/locale/ja-JP/changelog/2_4_2_2.md
+++ b/locale/ja-JP/changelog/2_4_2_2.md
@@ -1,0 +1,1 @@
+- Added: option to pay for premium packages using Blik

--- a/locale/ja-JP/changelog/2_4_2_3.md
+++ b/locale/ja-JP/changelog/2_4_2_3.md
@@ -1,0 +1,3 @@
+- Added: ability to follow conference channels (followers receive notifications whenever somebody joins the channel)
+- Changed: console now includes more settings and has better formatting abilities, coworked with Grzegorz Złotowicz
+- Changed: changes related to API, new format of Elten programs is supported

--- a/locale/ja-JP/changelog/2_5.md
+++ b/locale/ja-JP/changelog/2_5.md
@@ -1,0 +1,25 @@
+- Added: possibility to use VST plug-ins in conferences
+- Added: ability to overlay VST plugins on other users and preprocess their streams
+- Added: ability to stream conferences to shoutcast servers
+- Added: ability to inherit permissions in groups
+- Added: search on blog
+- Added: ability to stream from URL in conferences
+- Added: channels in conference mode where only selected people can speak, option to request speech is also available
+- Added: ability to set ringtones for individual users
+- Added: possibility to insert chapters in audio content
+- Added: ability to create posts in forums with MarkDown support
+- Added: online monitor
+- Added: channel whitelisting in conferences
+- Added: ability to create hidden channels in conferences
+- Added: roundtable mode in conferences, automatically positioning users
+- Added: Frequently asked questions
+- Added: new translation - Lithuanian (thanks to user vycka30)
+- Changed: Answers in polls are now sorted in descending order, contribution by Grzegorz Złotowicz, thank you.
+- Changed: when creating blog entries, you can add tags from the list of existing ones, contribution by Arkadiusz Kozioł, thank you
+- Changed: during spell checking, you can manually enter an alternative form, contribution by Arkadiusz Kozioł, thank you
+- Changed: replies to new entries on followed blogs are now sorted by date, contribution by Grzegorz Złotowicz, thank you.
+- Changed: During the speed test, the number of failed attempts is also given, contribution by Deniz Sincar, thank you
+- Changed: new streaming system in conferences to allow separation of stream and voice, as well as muting user streams and positioning them independently of the user
+- Changed: minor interface changes
+- Changed: updated libraries
+- Fixed: numerous optimisations of the conferences

--- a/locale/ja-JP/changelog/2_5_1.md
+++ b/locale/ja-JP/changelog/2_5_1.md
@@ -1,0 +1,3 @@
+- Added: transcriptions of audio forum posts, currently only in recommended groups
+- Added: Braille symbols for description of specific tags on list boxes, contribution by Deniz Sincar, thank you
+- Added: Possibility of mentioning multiple users at once, contribution by Arkadiusz Świętnicki, thank you

--- a/locale/ja-JP/changelog/2_5_1_1.md
+++ b/locale/ja-JP/changelog/2_5_1_1.md
@@ -1,0 +1,7 @@
+- Changed: Elten NVDA Addon updated for compatibility with NVDA 2023.1
+- Changed: downloading of Elten programs has been rewritten
+- Changed: it is now possible to assign quick actions for list of all messages in a conversation, regardless of their subject
+- Fixed: Some programs could cause crash when playing sounds
+- Fixed: some configuration could be lost after closing Elten
+- Fixed: Elten now remembers last selected tag when reading a thread
+- Fixed: translator sometimes only translated part of the text or even caused a crash

--- a/locale/ja-JP/changelog/2_5_1_2.md
+++ b/locale/ja-JP/changelog/2_5_1_2.md
@@ -1,0 +1,1 @@
+- Changed: Opus updated to version 1.4

--- a/locale/ja-JP/changelog/2_5_1_3.md
+++ b/locale/ja-JP/changelog/2_5_1_3.md
@@ -1,0 +1,3 @@
+- Added: tools for mass actions on posts and threads for moderators
+- Added: library for saving bloghs and getting quick access to them
+- Fixed: links in blog posts and comments open correctly

--- a/locale/ja-JP/changelog/2_5_2.md
+++ b/locale/ja-JP/changelog/2_5_2.md
@@ -1,0 +1,12 @@
+- Added: ability to upload sound themes to the server
+- Changed: New interface for downloading sound themes
+- Changed: in conference mode it is now possible to deny voice of all users
+- Changed: Ruby updated to version 3.2
+- Changed: It is now possible to like/dislike feed messages from the invisible interface
+- Changed: It is now possible to send the user submitting a post report a notification that the report has been processed
+- Changed: closed post reports in the list are accompanied by a sound
+- Fixed: Branches in the settings are signed correctly
+- Fixed: when minimizing the Elten window during a call, the call was interrupted when restored
+- Fixed: When editing a blog post, the tickbox for scheduling a post was sometimes checked even though the post had already been published
+- Fixed: it was possible to cause a stack overflow by continuously calling the feed message window
+- Fixed: when editing blog settings, attempting to change the domain resulted in the loss of previously made changes

--- a/locale/ja-JP/changelog/2_5_2_1.md
+++ b/locale/ja-JP/changelog/2_5_2_1.md
@@ -1,0 +1,5 @@
+- Changed: From now on, premium functions are visible in the menu even if user does not own the respective package.
+- Changed: It is now possible to purchase premium packages for one month and in other currencies
+- Changed: Groups moderated by banned users are no longer displayed in most lists.
+- Changed: It is possible to prevent banned users from sending private messages, this option is enabled by default
+- Fixed: Problem with audio content recording at sample rates not supported by the Opus codec

--- a/locale/ja-JP/changelog/2_5_2_2.md
+++ b/locale/ja-JP/changelog/2_5_2_2.md
@@ -1,0 +1,6 @@
+- Changed: when Elten is started, the previous log is retained
+- Changed: Banned persons cannot edit their posts or add reactions
+- Fixed: when downloading a sound theme, several windows with the sound themes list were overlapping each other
+- Fixed: attempting to pay blik for premium packages caused an error
+- Fixed: people with the audiophile package could not create permanent channels
+- Fixed: some of the available options were sometimes not displayed in context menus

--- a/locale/ja-JP/changelog/2_5_2_3.md
+++ b/locale/ja-JP/changelog/2_5_2_3.md
@@ -1,0 +1,8 @@
+- Added: it is possible to archive an account (archived account does not show up in lists, cannot receive messages, is not a member of groups, has no profile)
+- Changed: it is possible to complete a profile without entering a date of birth
+- Changed: The in-flight data compression function has been implemented, which should speed up connections to the server.
+- Changed: NVDA add-on is compatible with version 2024.1
+- Changed: In polls, questions can be created with a limited number of answers to be selected
+- Fixed: text fields should be read correctly when using the RHVoice synthesiser
+- Fixed: when refreshing a thread, previously entered answer content does not disappear
+- Fixed: Elten should no longer freeze when no internet is available

--- a/locale/ja-JP/faq.md
+++ b/locale/ja-JP/faq.md
@@ -1,0 +1,285 @@
+# General
+## Who created Elten, who manages it?
+Elten was created by David Pieper, pajper on Elten.
+Information about the people who administer the portal or parts of it can be found in the menu, 'Community', 'Users', 'Administration and authors'.
+In the legal sense, the project is the responsibility of the "Fundacja Prowadnica" ("Prowadnica Foundation"), established by the author and registered in Poland in the Register of associations, other social and professional organisations, foundations and public health service establishments of the National Court Register under number 0000893029, VAT-UE PL5882467405, REGON 388594504.
+You can read more about the Foundation on its website (only in poloish) [prowadnica.org](https://prowadnica.org).
+
+## Is there or will there be an Elten for other hardware platforms?
+At the moment Elten is only available for Windows. There have been reports of success in running the program using the Wine emulator, but this method is not officially supported and we cannot vouch for the correct functioning of it.
+There are plans to develop a mobile version for iOS and Android, but we cannot provide any dates at this time.
+
+## How can I contact the administration or the developer of Elten?
+Information about the people who administer the portal or parts of it can be found in the menu, "Community", "Users", "Administration and authors". From here, you can send the relevant users a private message.
+You can also contact them in other ways; please have a look at the visitingcards of the respective administrators, where you may find other contacts.
+The project administration can also be contacted directly by e-mail at [support@elten.link](mailto:support@elten.link).
+The "Prowadnica Foundation", which runs the project, can be contacted at [fundacja@prowadnica.org](mailto:fundacja@prowadnica.org). Please note that we do not provide any technical or other support regarding Elten at this address.
+
+## Where can I report a bug or a proposal?
+The best place is the designated forums of the group "Elten Development" (Polish language) or "Elten Development" (English language).
+Bypassing these avenues and the beta tester groups, other submissions, especially proposals, will not be acknowledged.
+
+## How do I install sound themes?
+Sound themes available in the server repository can be downloaded from the menu, "Tools", "Sound themes", by selecting "Download sound themes" from the context menu.
+Elten's sound themes are saved in files with the extension *.elsnd and are located in the "%appdata%\elten\soundthemes" folder, where %appdata% stands for the Roaming folder of the application data.
+To get to this folder, the easiest way is to press WINDOWS+R, type "%appdata%" in the "Open" field and press enter.
+
+## How do I create a sound theme?
+You can create your own sound theme from the menu, "Tools", "Sound themes", by selecting "New" from the context menu. A list of sounds will be presented, which can be freely edited.
+The theme created in this way can be sent to the members of the Elder Council for approval and placement in the server repository, or it can only be used privately or shared through other means.
+
+## Does Elten support screen readers other than NVDA?
+Elten does not support other screen readers. However, it is possible to use SAPI5 synthesisers.
+
+## How can the project be supported?
+Support for the project can be divided into tangible and intangible.
+The forms of financial support are the purchase of premium packages or simply donations destined for the "Prowadnica Foundation".
+In addition to money, Elten also needs programmers, translators and testers. If you can code or know a language into which the program is not yet translated and you want to help, feel free to contact the Elder Council.
+
+## How and what to use the invisible interface for?
+The Invisible Interface is a feature that allows you to perform key actions from anywhere in Elten or even other applications. For example, it is possible to exchange private messages with other users while browsing the Internet or writing a document in Word.
+The Invisible Interface is a series of selectable keyboard shortcuts that will allow you to read information or display a reply window. A list of these shortcuts can be found in the "Help" menu, "Invisible Interface Keyboard Shortcuts", and changed in the "Tools, Program Settings, Invisible Interface" menu.
+
+## How to use braille displays in Elten?
+Elten only allows braille displays to be used via the NVDA screen reader. Make sure that a dedicated add-on is installed and then enable the appropriate setting from the "Tools" menu, "Program settings", "Voice".
+
+## Where can I find the file manager, playlist and other features to extend Elten's capabilities?
+Options such as the file manager were an integral part of Elten until version 2.4. Since version 2.4, they have been removed from it and made available as "Programs" - plug-ins to extend its functionality.
+These can be downloaded from the "Programs" menu, "Install new programs".
+
+## Where can I get information about the Elten betatesting?
+Before each release of a stable version of Elten, there is a testing phase in which at least a few dozen beta versions are usually released. These versions contain untested new features. Testers actively evaluate new developments and point out bugs.
+It is worth noting that many beta proposals do not pass this verification phase and, under the influence of the testers' evaluation, are completely changed or rejected.
+Before installing a beta version, it should be borne in mind that it is untested software in which numerous bugs will be present. It is not recommended that less technical users join the beta test.
+Information about the beta tests is published in the Polish and English official forums, where you can also find information about signing up for them.
+
+## How do I create a portable version of Elten?
+A portable version can be created from the menu, "Tools", "Create portable version". In the same place, you can decide whether to copy the current settings into the version to be created.
+Please note that the portable version cannot be updated.
+
+## Menus versus context menus, what is the difference?
+The context menu contains the options associated with the currently selected control. For example, in the list of forums, it will contain the options for the selected forum. The context menu is opened using the applications key and, by default, the SHIFT+F10 shortcut assigned via a quick action. This shortcut can be changed or deleted.
+The menu opened with the alt key allows you to open the most important options of the program, such as messages, forums and settings.
+If a context menu is available at a given location, its options are also displayed at the beginning of the menu bar by default. This behaviour can be changed from the settings, in the "Interface" section under the option "Display context menu in menu bar".
+
+## How do I update Elten?
+By default, Elten checks for the availability of a new version on start-up. If a new version is available, a message will be displayed suggesting an update. This behaviour can be deactivated from the settings, in the "General" section under the option "Check for updates on start-up".
+In addition, if a new version of the program is available, this will be displayed under "What's new".
+It is also possible to force the installation of the latest version. To do this, use the option available in the menu, "Tools", "Reinstall program". The program will ask which version should be installed. Select the option to install the latest version from the server.
+
+## What does the plug-in for NVDA provide?
+A dedicated plug-in for the NVDA reader enables Elten to support braille displays and scroll through text as it is read.
+Its use is not required but is highly recommended.
+
+## Where can I find information about new features being introduced?
+All new developments in Elten are listed in the changelogs, available in the "Help" menu, "Changelog".
+
+## How do I browse the file lists?
+File lists are available in the form of a tree. Folders are expanded and collapsed using the left-right arrows.
+Note: Do not use the enter key to open folders.
+
+## How do I use the settings windows?
+Most places for settings, including program, group, blog or account settings use the same layout, where the window is divided into categories (settings sections) and specific options.
+In these windows, the first element is a list of categories. Selecting a category will change the contents of the window, specific items are available by pressing the tab.
+
+# Accounts
+## Where can I change my user data?
+All profile data can be changed using the option available in the menu, "Community", "Manage my account".
+There you can change both the data visible to the public (age, place of residence, name, visitingcard), as well as your account password, enable two-step verification or view your logins.
+
+## What are premium features, what do they offer and how much do they cost?
+Information on the current prices and content of each premium package can be obtained from the menu, "Community", "Premium packages".
+
+## Can I change my user name?
+Unfortunately we do not provide for this option.
+
+## What is two-step authentication and why is it useful?
+Two-step authentication is a way to protect your account even if someone learns your password. The first time someone logs in from a new device, a special code will be sent to the mobile phone number associated with the account, which must be entered to complete the login. In this way, a person without access to your mobile phone will not log in to your account.
+Two-step authentication can be enabled in the menu section, "Community", "Manage my account", under "Security", "Two-step authentication settings".
+
+## How do I view my account activity information?
+In the menu section, "Community", "Manage my account", under "Security", "Recent logins", you can find a list of recent logins, including date and IP address. If you see anything suspicious here, change your account password immediately. Also remember to check whether any new automatic login keys have been created. You will do this by using the "Auto login keys" section in the same tab.
+
+## How does automatic login work?
+When automatic login is activated, a special key will be created to access your account. This key will then be stored on the computer from which the login is made.
+In addition, it can be protected by a pin code.
+You can view and delete keys in the menu section, "Community", "Manage my account", under "Security", "Auto login keys".
+
+## How do I change my password?
+The password can be changed in the menu section, "Community", "Manage my account", under "Security", "Change password".
+
+## What is the difference between a pin code and a password?
+A password is an essential element when logging into your account.
+The pin code is associated with a particular auto login key - it is the key used to encrypt it.
+The pin code only applies to one key and the computer on which that key was created.
+
+# Forum
+## What is the idea behind groups?
+Groups are communities in which forums are created. In practice, the entire EltenLink portal forum can be divided into groups, which in turn can be divided into forums, threads and thread posts.
+Each group can have its own rules and has its own administrator and moderators. A user can be subscribed to any number of groups.
+Another difference is the method of joining. Groups can be public, so that any user can read the content created on them and contribute to discussions. There are also hidden or moderated groups, where users can only join with the permission of the moderators.
+
+## How do I create and manage a group?
+Groups are created from the "New group" option, available from the context menu in the list of groups. It can be opened via the menu, "Community", "Forum".
+All group management options are available in the context menu of the specific group.
+New forums are created by entering the group and selecting "New forum" from the context menu. Only the administrator can add and delete forums in a group.
+
+## What is a recommended group?
+Recommended groups are special groups that are selected by the council of elders. They can be found in the "Recommended Groups" section, and by default threads are searched in them. They are always open and public groups.
+Detailed guidelines for these groups can be found in the EltenLink Rules.
+
+## How can I set up my own language group?
+There can only be one language group, i.e. the primary recommended group in a given language. If such a group already exists, it is not possible to set up another one.
+If a language community has not yet been officially established and there is a language group with many active members, please contact the Elder Council.
+
+## What are forum tags?
+Tags were created to help filter a thread. They can be defined by the group administrator, or they can be created from the bottom up.
+Administrator-defined tags are available for selection in the topic creation window.
+Freely defining tags requires the tag (one word) to be enclosed in square brackets, for example "[trivia]".
+Tags created in this way can be easily filtered, simply use the Shift shortcut in the relevant forum and the up or down arrow to select a tag. Only the topics containing it will be displayed.
+
+# Conferences
+## What is space in conferences?
+Space in conferences works analogously to an actual room. Imagine a large room. Moving around in it, we can divide the participants in the conversation into smaller groups and then move freely between these groups.
+This is how conferences work. By moving through the space, we can change our position in relation to other users. It's easy to imagine three independent conversations going on simultaneously on one channel, and the participants can easily move between them.
+
+## What is the HRTF?
+HRTF (head-related transfer function) is a method to virtualise real space. In HRTF channels, when you put on headphones, you can actually hear the relative positions of the users, taking into account whether the person is in front or behind you.
+
+## What is a roundtable?
+A channel in roundtable mode has no space. All users in it are automatically positioned as if they were sitting at the same table.
+As a result, each user is heard from a slightly different direction, but at the same volume. HRTF is used in this mode.
+
+## Why is Elten asking me to download the HRTF library?
+Phonon, the HRTF effects library used by Elten, is relatively large. Including it with each version of Elten would significantly increase the size when downloading both Elten itself and subsequent updates. We have therefore decided to supply it separately, so that its installation is only required once.
+
+## What are whispers and how to use them?
+A whisper is a message that is only heard by one selected person. It can be used to communicate confidential information or minor arrangements without changing the channel or using private messages.
+To whisper to a user, simply press and hold the space bar on the appropriate person in the conference list. Releasing the space bar is the same as stopping the whispering.
+
+## What is the "Press and Speak" function?
+The "Press and Speak" function allows us to make the sound from our microphone only broadcast when we press the selected key sequence.
+
+## What is the difference between conferences and voice calls?
+Technically nothing apart from the way they are initiated.
+When you call another user, they will receive a notification with the option to answer the call. If he or she chooses to do so, a special private conference channel will be created and the callers will be connected to it.
+
+# Messages
+## How does Elten mail work?
+Elten mail is a simple mailbox that allows you to send and receive emails using Elten.
+Each user is created an email address in the domain "elten.me", for example the user "smith" will receive the address "smith@elten.me".
+When a message is sent to this address, it will be delivered as a private message. Similarly, sending a private message to an email address will result in it being broadcast from that account.
+
+## What are group conversations?
+Group conversations are special conversations in which any number of users can participate. They behave like any other messages.
+Group conversations can be created from the context menu.
+
+## How do I block a particular user?
+If you do not wish a particular user to send you messages, you can add them to a blacklist.
+You can do this from the menu, "Community", "Manage my account", category "Privacy", "Blacklist".
+
+# Blogs
+## How do Elten blogs work?
+Elten blogs are based on the popular CMS system WordPress. It is possible to view and manage them from both the client and the website.
+The Elten instance of WordPress has been enhanced with several additional functionalities for the program, including following other users' blogs or additional privacy settings.
+
+## How can I manage my blog settings?
+Managing blog settings from within Elten requires selecting the appropriate option from the context menu in the blog list.
+It is worth remembering that the WordPress admin panel offers many more options for blog customisation.
+
+## How do I log into the WordPress admin panel of my blog?
+The first step is to set a password. For security reasons, we recommend using a different password for the WordPress dashboard than for logging into Elten.
+In the list of blogs, select your blog and choose "Blog options" from the context menu. Then select the "Other" category and open the window available under "My WordPress account".
+From here, it is already possible to set a password via the "Set new password for your WordPress account" button.
+Once the password has been changed, you can log into the panel.
+From the "Other" tab visited previously, simply select "Open the WordPress admin panel in my browser" for this purpose.
+
+## Can my blog be observed by users who do not have Elten?
+Yes, as long as the posts have no other privacy settings. All they need to do is access the blog from their browser.
+In the blog's context menu, there is an option "Copy blog URL". This will copy the blog address to the clipboard. Using this, you can visit the blog from any web browser.
+Similarly, you can copy links to specific posts.
+
+## How do I change the web address of my blog?
+In the list of blogs, select your blog and choose "Blog options" from the context menu. Then select the "Other" category and open the window available under the "Manage blog domain" button.
+
+## Can I view other blogs written outside Elten from within Elten?
+Yes, but only blogs using WordPress, the specific action depends on the settings of the specific blog. But it's always worth a try.
+This option is available in the main blogs menu, under "Open external WordPress blog."
+
+## How do I format content on the blog?
+Two editors are available from within Elten: an editor with formatting and an HTML editor.
+Those familiar with HTML and WordPress tags can confidently use the second option. The first provides basic options such as creating headings or links.
+All options are available in the context menu.
+However, it should be borne in mind that these are the most basic tools. The full range of possibilities will be provided by using the WordPress editor on the website.
+
+# Polls
+## How do I answer a poll?
+Polls currently have three types of question: single choice, multiple choice and text boxes. An indication of the question type is always given next to the question.
+Single-choice questions only require an arrow to indicate the answer of your choice.
+Multiple-choice questions require you to select the answer you are interested in using the spacebar.
+Text boxes allow you to enter text.
+Move between questions using the tab key, as in any other form.
+
+## Why can't I answer the poll?
+Several reasons are possible.
+The poll may have already been completed by you, it may have expired or its settings limit the list of users allowed to respond.
+
+## What are the filters for?
+When viewing responses, it is possible to filter them. There are inclusion filters and exclusion filters.
+With inclusion filters, you can only view the answers given by those users who have selected the answer you are filtering in a given question.
+Exclusion filters work the other way round: they show the answers of those users who did not select the given answer.
+Example: one of the questions in the poll is about gender, the available answers are "Female", "Male", "I prefer not to specify". Selecting an on filter on the 'female' answers will only show the answers given by women in the survey, while an off filter on the 'I prefer not to give' answers will only show the answers of those who did not conceal this information.
+A number of filters can be combined, for example selecting only responses from people who are female and under the age of 20, depending on the available questions of course.
+Filters are available from the context menu in the list of answers.
+
+# Technical
+## What language is Elten written in?
+Elten is written in the Ruby language. Parts of the program are also written in C++.
+
+## Can I add anything from myself to Elten?
+We would be very pleased if you do.
+All information is available on the project's GitHub:
+[https://github.com/dawidpieper/elten2](https://github.com/dawidpieper/elten2)
+
+## Where can I find the Elten API documentation?
+Official documentation does not exist, but it is possible to generate it via rdoc from the code.
+
+## Can I translate Elten into a new language or improve an existing translation?
+Yes, we would be delighted! Write to the Council of Elders about such a desire.
+
+## How can I debug problems in Elten?
+The most important tool is the log, found in the "Tools" menu, "Log overview", and also in the file "%appdata%\elten\elten.log", where %appdata% stands for the Roaming folder of the application data.
+To access this folder, the easiest way is to press the WINDOWS+R key combination, enter the text "%appdata%" in the "Open" field and press enter.
+If you do not see a trace of the error despite selecting the "debug" login level, a more specific approach may be required. Feel free to contact us, we will look for a solution together.
+
+## Where does Elten save the settings?
+All settings are saved in the folder "%appdata%\elten", where %appdata% stands for the Roaming folder of the application data.
+To access this folder, the easiest way is to press the WINDOWS+R key combination, enter the text "%appdata%" in the "Open" field and press enter.
+
+# Solutions to common problems
+## The "Invisible interface" does not work.
+Most likely the problem is related to the keyboard shortcut used. It may be that it is already used in another program.
+The keys used by the "Invisible interface" can be changed from the "Tools" menu, "Program settings", "Invisible interface" category, "Modifiers" option.
+
+## Automatic login does not work for me.
+This problem can sometimes occur after a program update.
+Deleting the file "%appdata%\elten\login.dat", where %appdata% stands for the Roaming folder of the application data, may help to solve it.
+To get to this folder, the easiest way is to press WINDOWS+R, enter the text "%appdata%" in the "Open" field and press enter.
+It is also possible that automatic logging is simply disabled from the "Tools" menu, "Program settings", "General" category, "Enable automatic logging" option.
+
+## I cannot be heard in conferences.
+This problem can be attributed to several causes.
+From the "Tools" menu, "Program settings", "Sound devices" category, "Microphone" option, check that the correct device is selected.
+Elten may have a problem automatically detecting the default device, try deliberately pointing to the correct one. If possible, it is worth testing several different microphones.
+If the problem persists, perhaps the microphone is set to too low a sensitivity in the system or the software itself.
+During a call, select the "More options" button, "Change volume". Make sure that the "microphone volume" is appropriately high, 100% corresponding to the level in the system.
+It is also worth checking in the same "More options" menu that "microphone mute" is switched off and that "Press and speak" is not switched on by mistake.
+If none of the following steps help, check the log for errors.
+If chat messages are also not arriving or the connection is dropped after a short time, the problem may relate to the firewall in use. Make sure Elten is authorised to connect to the network, including UDP connections. The port used for conferencing is 8133.
+
+## When the computer goes to sleep or the headphones are connected/disconnected, Elten loses sound.
+Some sound card drivers cannot handle these events correctly, instead duplicating their instances.
+The solution may be to force the use of the default card instead of the explicit selection used in the 'Tools' menu, 'Program Settings', 'Audio Devices' category, 'Output Device' option.
+
+## I cannot change the playback tempo.
+It is likely that FX effects have been disabled. You can enable them in the "Tools" menu, "Program settings", "Advanced" category, "Enable FX effects" option.

--- a/locale/ja-JP/invisibleinterface.md
+++ b/locale/ja-JP/invisibleinterface.md
@@ -1,0 +1,42 @@
+# Invisible Interface: or the most important feature of Elten 2.4.2!
+
+## What is the "invisible interface"?
+
+The name of this phenomenon is perhaps not entirely apt, and certainly in the case of Elten, after all its interface is always invisible! But let's leave that aside and get to the point. The invisible interface allows you to use the most important features of Elten, ie. whiteboard, messages, or to manage the current conference from anywhere in the program, but, most importantly, also when its window is minimized.
+This is made possible by the concept that is Elten "modifier". If you use any Screen Reading program (you certainly do), you have more than once, more than twice, used the INSERT key combined with other keys to perform some of its functions.
+Elten behaves similarly in this matter, although its modifier is slightly different (WIN+CTRL+ALT by default). Don't worry about the multitude of keys, as these three are right next to each other on most keyboards, so pressing them is not difficult. Additionally, there is an option to change the modifier from within the settings.
+Note: If the default key combination is already used by another program, Elten will automatically try to find another free combination. The currently used combination can be found in the footer of this document.
+
+## Why do I need to do this! I have an Elten window, I know an Elten window, I love an Elten window!
+
+Sometimes there are situations when you are doing something extremely important on your computer and suddenly you get a message, the one and only message, the one you have been waiting for since 5:54 am the day before. In the old version you would have to go to Elten window, open message screen, conversation, read the message, reply and go back to work.
+Now all you have to do is press a few keys to do this. You don't even have to minimize the application you are currently using!
+
+## So what are these shortcuts?
+
+A complete list of the shortcuts that work in Elten invisible interface can be found in the "Help" menu. Below are the most important ones. In the list below, the abbreviation MOD stands for Elten modifier.
+- MOD+UP/DOWN ARROWS: goes to next or previous item on a list.
+- MOD+LEFT/RIGHT ARROWS: Changes the current tab of the invisible interface.
+- MOD+SPACE: Repeats the last spoken invisible interface item.
+- MOD+R: Responds to the currently selected message or feed post.
+- MOD+M: Opens a window for creating a new message.
+- MOD+F: Opens a window for creating a new feed post.
+- MOD+ENTER: Activates the currently selected option.
+- MOD+BACKSPACE: Mutes speech if you are using the SAPI output on Elten, as well as the audio stream.
+
+## Invisible interface settings
+
+There is a new "Invisible Interface" tab in the Elten settings from now on. It will be described below.
+
+- Modifier: Allows you to change the modifier (the first three keys required for the invisible interface to work).
+- Tabs to show: Allows you to choose which tabs you want to see and which you don't.
+
+For example, if you never use feed, you can safely uncheck this tab.
+
+## The invisible interface doesn't work! What to do!
+
+If the Elten invisible interface refuses to work on your hardware, it is likely that the modifier selected by Elten is no longer available. Try changing the modifier in the settings. Perhaps the selected combination is already used by a screen reader or other applications?
+If you have further problems, feel free to post questions in the forum.
+
+
+The above document was written by user nuno69.

--- a/locale/ja-JP/migration24.md
+++ b/locale/ja-JP/migration24.md
@@ -1,0 +1,226 @@
+Dear users! After more than a year of testing, we are giving you the final release of Elten 2.4, the biggest update to the program since version 2.0.
+Due to many changes and innovations, in this document we will try to highlight the most important differences between version 2.4 and previous 2.3.8. If you have any questions, feel free to ask them in the forum, where testers and other users will be happy to try to resolve all doubts.
+Please note that not all changes are listed here, but only those we found most significant or interesting.
+
+# General changes
+## Change of portal name and addresses
+From January 24, 2021, the portal name "Elten Network" has been replaced by "EltenLink" The client, at least for now, remains under the name Elten.
+The addresses have also been changed:
+* The main project website at
+https://elten.link
+currently contains information about the nature of the Portal, but more content will be made available over time. The old site is at its current address, but will be gradually phased out in favour of the new one.
+* All blogs on Elten have been moved to the address
+elten.blog
+so if your blog was previously at
+xyz.eltenblog.net
+from now on its site will be
+xyz.elten.blog
+* Individual e-mail accounts have been moved to the address
+login@elten.me
+Until the end of 2021 emails sent to the old address will still be forwarded to the new one. This is the time to communicate the change of address to interested senders.
+## New project logo
+The EltenLink project logo now shows a laptop on a blue background. On the screen is presented a yellow guide crossed by the tip of a white cane. At the edge is the word Elten(*)Link separated by a 6-pointed star.
+## NVDA addon
+If you use an NVDA screen reader, you will be pleased to know that from now on you can install an addon that will make working with Elten easier by allowing you to use braille displays or scroll text as you read. If NVDA is installed on your computer, Elten automatically should ask if you wish to install the addon; you will be guided through all the installation steps, which are very similar to installing a typical NVDA addon. Whenever there is an update to it, Elten will inform you about it at startup.
+## Context Menu
+From now on, all local functions specific to a section are available in the context menu.
+To open it, you can press the context menu key on your computer or Alt - this will be the first menu tile on the left. If you don't want the context menu to show in the menu bar under alt, go to Tools/Program Settings/Interface and uncheck Display context menu in menu bar.
+Another way to access the context menu, useful if your computer doesn't have a predefined key, is to use the Quick Action shortcut, SHIFT+F10 by default.
+## New dialog and menu layout
+From now on, the layout of dialog boxes and context menus corresponds to that known from operating systems. All confirmation dialogs and context menus should be navigated with the up/down arrows.
+## Premium Features
+Elten Ling, like any service, requires not only the time needed to develop it, but also the money needed to pay for the servers.
+Therefore, since version 2.4, so-called premium features have been introduced to make the program more enjoyable to use and at the same time to allow for its further development.
+The proceeds from their purchase go only to the maintenance of the server; as of version 2.4, the developer derives no material benefit from the development of the project.
+You can read more about package prices and how to get them in your language group's Elten development forum and in the Premium section under Community/Manage my account.
+## Audio representation of lists and menus
+From now on, each item in a list or menu will have a slightly different audio representation depending on where it is located (more at the beginning or the end) - items at the beginning are heard on the left, and items at the end are heard on the right.
+To change this setting, go into Tools/Program Settings/Interface and deselect the Use stereo positioning for user interface checkbox with a space.
+ATTENTION!
+Positioning does not apply to speech synthesis, only to the sound theme.
+## Content only in known languages
+Elten will no longer display groups, polls or forums in unknown languages if you select the ones you speak.
+To do this, go to Community/Manage My Account/Languages and select all the ones you know.
+If you still want to see, for example, in the list of groups, those in unfamiliar languages, select the appropriate option from the context menu for the given section.
+
+# Quick Actions
+Until now, Elten's main window remained empty and you had to use menu to access any of the functions; now this space has been taken up by the Quick Actions. These are shortcuts similar to those you may find on your desktop - links to programs, notes, links, etc. In Elten, such a shortcut can be created for virtually any function, including groups, forums, blogs, conversations, specific functions (such as conferences), settings, etc. To get to the desired location, you simply need to click Enter on the action or use the shortcut assigned to it (more on this below).
+## Adding Quick Actions
+Most items in the program now have a context menu, which allows you to access local functions specific to that item or window. It also allows you to add an item to Quick Actions.
+So, for example, if you want to add a favourite blog to this list, position yourself over it in the list of blogs, open the context menu and click Add to Quick Actions and the item will land at the bottom of the list in the main window.
+Another way to add an item, mainly options from the main menu that are impossible to add from the context menu, is to click Ctrl+N in the main window of the program or open the context menu and select the appropriate option. In both cases, you will find yourself in a window, which will allow you to select the action you are interested in from a list of available actions and add it.
+Let's imagine that we want to create a shortcut to the notes. This option is available from the main menu, so you can not open the context menu on it. That's why in the main window, in the list of actions, we click the context menu, click Add and select the Notes we want from the list, confirming with the Enter key.
+## Changing the keyboard shortcut
+In the context menu of the quick Action, or by the shortcut Ctrl+K, we can change the keyboard shortcut for each action. This is a global shortcut, which will work in the whole program. For example, if you want to quickly access a conference while browsing the forum, just press the shortcut of your choice.
+NOTE!
+The list of shortcuts is limited to function keys (F1-F12) and their combination with the Shift key (Shift+F1-F12).
+ATTENTION!
+Opening a context menu can also be a Quick Action! :)
+ATTENTION!
+The current form of the program assumes the absence of any global shortcuts for functions that had them before, e.g. saying the date, time, last spoken message, pausing/resuming media, etc.
+The only way to keep such a shortcut is to add the appropriate action in the main window, set the appropriate shortcut and hide the action.
+Note that some of the default Quick Actions are hidden.
+## Hiding Fast Actions
+To keep the list of Quick Actions in the main window short, you can hide some of them. This is especially useful for actions like saying an hour, which are usually only called by a shortcut. Note that some of the predefined Quick Actions are hidden by default.
+Let's imagine that we want the F8 key to tell the time, as it used to.
+We add an action to the main window via the context menu or the Ctrl+N key.
+The action is now at the bottom of the list. For now, it can only be called by pressing Enter.
+Set a keyboard shortcut for the action by selecting the appropriate option from the context menu or by clicking Ctrl+K and selecting F8 from the list of available shortcuts.
+Now we can call the action not only with Enter in the main window, but also with a shortcut in the whole program.
+If necessary, we can hide the action in the context menu.
+From now on, it will not be visible in the main window, but the shortcut will still work.
+To display all hidden actions, click Show Hidden Actions in the context menu. To hide them again, click Hide Hidden Actions.
+
+# Messages and conversations
+## Editing a group conversation
+If you don't like the name of a conversation you belong to or want to manage its members, just open the context menu on it after setting yourself in the conversation list and click Edit Group Conversation or press ctrl+e. The window you will land in allows you to rename the conversation and add people.
+## Muting a conversation
+If you temporarily want to suspend notifications from a conversation as you can do in popular instant messengers, position yourself on it with the arrow in the conversation list and select Mute this Conversation from the context menu. The window you will be in allows you to pause notifications for a quarter of an hour, an hour, a day, a week, or forever, that is, until you turn it back on.
+
+# Blogs
+From May 2020, Elten uses the WordPress system as its blogging engine. This allows for blogs that are easily customisable and aesthetically pleasing to external visitors.
+Each blog has its own unique address in the elten.blog domain. From the blog's context menu, the address can be previewed.
+Depending on the configuration, external visitors can view blog posts and/or post comments on the blog.
+## Blog Settings
+From now on, you will find all the options for your blog in one place. You will access them from the context menu when you position yourself on the managed blog in any blog list.
+You'll select a settings category with the arrow, and reach a specific setting with the Tab key.
+Attention!
+Here it is also possible to change the Internet address of the blog (premium feature).
+## Generating a password for your WordPress account
+From the Other Settings tab of any blog, you can go to My WordPress account. This is where you can set a password that will allow you to log in through a page where you can configure settings that are not accessible from within the program, including enabling plugins or switching between themes.
+## Following a blog post
+A blog post can be followed, just like a forum thread. You'll receive notifications of every new comment on it. To do this, position yourself on it in the list of posts and select the appropriate option from the context menu or press Ctrl+L. This can also be done inside the post.
+NOTE!
+Premium feature, available in the Courier package.
+
+# Forum
+Most of the changes to the forum include new moderation tools. These allow you to manage the group more effectively, but the information on them will also be useful for users. Key new features include:
+* Closed forums - users cannot create new content in these forums, that is, in a closed forum you cannot add new threads. It should be noted here that you can add posts in open threads in a closed forum. Closed forums are marked with an appropriate sound.
+They can be used, for example, to add announcements, archive forums and threads and create forums where new threads can be created only by the moderation of a given group.
+* Tags - sets of values defined by moderation.
+This is used to organise a forum if it is large or diverse. For example, instead of creating a separate forum in the Polish Elten Community for 18 plus content, they will be tagged with a specific tag. This way, the name of each such thread will be unified and there will be no need to isolate them. You can move between tags in the forum using the SHIFT key and the up/down arrows.
+* Offering threads - moving threads in groups 
+This function is used to conveniently share threads in groups. You no longer need to temporarily delegate permissions or create additional groups. Just select Offer this thread to another group or press ctrl+o and select a group from the list.
+* Locking a post - a locked forum post cannot be edited.
+* Report a post - if a post violates the rules of a group, you can report it to its moderation using the Report this post function located in the context menu.
+Apart from that, a few more non-moderation related new features have been made available:
+* Received mentions (premium feature) - this is a separate section in the forum, where we will review the received mentions. They are sorted from newest to oldest. When we focus on a particular mention, we can enter the thread with the right arrow and use the ctrl+slash shortcut to view its content in the edit field (function available in the basic version). We can also press ctrl+shift+slash to reply to a mention (premium feature). Such a reply will be sent to the sender as a properly formatted private message.
+* Forum tree sorting - in the context menu in the Forum section, we can choose how groups and forums should be sorted.
+* More extensive search engine - From now on, we can specify whether we want to find something in the title, the content, or the title and content of the thread. There are also several criteria available relating to the groups being searched.
+* Marked threads (premium feature) - These work similarly to followed threads, they appear in the list of forums but do not show up in What's New. Their use may depend on the user. For example, they can be used to mark threads to read later, threads that you particularly like, threads that contain relevant content, etc.
+* Bookmarks in threads (premium feature) - they are saved on the server and allow you to quickly jump to the saved posts. They can be viewed from the context menu/navigation, bookmarks or using the shortcut CTRL+B.
+* Mixed forums - these are forums where each entry can be either voice or text, at the author's discretion.
+* Likes - a function known from many popular forums and discussion groups, from now on from the context menu and using ctrl+k shortcut you can like a post you are on. When the post is liked by at least one person, the information about the number of likes will be displayed between the post content and the user's signature. You can also check who liked a post from the context menu or by using the ctrl+shift+k shortcut.
+* Group Rules - if the group has rules, each user can read them from the group menu, and in addition, he must accept them when joining, also when joining automatically by posting a thread or post in an open group.
+* Message of the day - it is possible to set a message of the day in the group, which after each edit will be displayed to users who want to browse the group. This does not apply to viewing threads from the group through the search engine or what's new.
+Minor changes can also be highlighted here:
+* The Shift+Enter key combination or the corresponding option in the context menu displays all the threads in a group by the date of the last entry.
+* When moving an entry, the threads are sorted by group.
+* When closing a non-empty thread creation window and a thread with a non-empty reply, a prompt to confirm the abandonment of the entry is displayed.
+* There is an appropriate annotation under edited posts.
+* From the context menu, it is possible to display the original content of a post
+* While editing posts, it is possible to add and remove attachments
+
+# Polls
+Since version 2.4 it is possible to interpret the results of polls in more detail. The old look of the responses can be obtained by selecting Show Report, while the new, Show Results features the ability to view responses to a specific question as well as the ability to filter responses. Thanks to this you can e.g. check what was marked in question 2 by people who had marked "Yes" in question 1 or who haven't marked "No".
+You can also create hidden polls and share them in groups or in private messages (Courier premium package).
+
+# Settings
+To access the program settings, open the menu with the Alt key and select the Tools section.
+The Elten settings window has been rebuilt so that it now more closely resembles the windows of many other programs, such as NVDA. When you enter it, you will find yourself in a list of categories; select one by hovering the arrow over it, and navigate through the settings belonging to it with the Tab key.
+## Announcement of types of controls
+If you want to be informed about a type of control (button, list, etc.) in a specific way (by sound, voice or voice and sound), go to Tools/Settings/Interface and press the Tab key until you get to the field Announcement of types of controls, which allows you to select the option you want. You can make Elten inform you about the type of control by sound only (a different sound for a button, a different sound for a list, etc., without any voice information), by voice only (no sound information), and by both voice and sound.
+NOTE: Remember that sounds for other events will still be played unless otherwise selected in the sound theme settings.
+Remember to save your settings before you exit the window.
+
+# Help
+## Changelog
+From version 2.4 the changelog is available for translators to adapt to all languages supported by the program.
+## Program Version
+The Program Version window has been rebuilt to convey information about both Elten's compilation number and the libraries used.
+## Sound guide
+Elten is now able to explain to you what the different sounds of your sound theme mean; just go to Help/Sound Theme Guide and you will find yourself in a list that contains all the sounds with explanations. To play a particular sound, press the space bar; to stop it playing, press the Tab key twice to reach the Stop button.
+NOTE!
+Elten also allows you to edit the sound theme, i.e. to customize the sounds according to your preferences; to do this, go to Tools/Sound Themes, position yourself on the downloaded theme you are interested in, and select Edit from the context menu.
+
+# Tools
+## Install/reinstall the program
+From now on it is possible to install or reinstall Elten from the Tools menu.
+* If you are using the stable version, this option allows you to reinstall the program in case of detected errors.
+* If Elten was started from a portable version, it is possible to install it on your system from this menu.
+You can either install the version currently running or download the latest version available from the server.
+## Log viewer
+This is a useful feature when you want to troubleshoot a program or test something; to see the logs, go to Tools/Log viewer. You will find yourself in a window, which allows you to choose the type of event and specify its parameters. In the list below you will find the events found. If you are not an advanced user, navigate the window with caution and do not hastily use the information you get from it.
+
+# Conferences
+Since version 2.4, Elten also allows you to make voice calls. Conferences, as this feature is called, allow you to create channels in which conversations can be held.
+These are fully encrypted so that no outsider can overhear them.
+## Channels
+Channels in conferences can be of two types:
+* Group, created by the group administrator and visible only to members of that group,
+* Private, created by users and visible to all other users.
+If you want to ensure the privacy of your conversations, you can set a channel password that the person joining the channel must enter.
+After selecting Conferences from the menu, a list of available channels will appear. To join one of them, press the Enter key on it or select Join from the context menu. If you want to create your own channel, select Create channel or press CTRL+N shortcut.
+## Surround sound
+It is possible to create channels with surround sound (HRTF). In these channels, users can move around in space, emulating a natural conversation. You can use this feature to plan a podcast or conference call, for example.
+The applications of this capability are almost limitless and depend only on the imagination of the users. For example, you can step aside to discuss an issue without disturbing others, or divide a conference into several independent groups/stands that operate independently but allow you to move between them easily.
+To create a channel with surround sound support, simply select the appropriate option in the channel creation window.
+## Objects in Channels
+Objects in channels are background elements that can add ambience or provide reference points for users. There are a number of predefined objects that can be placed in the space, and users with the Audiophile package can also add any sounds of their own.
+## Moving through a channel space
+You move around a channel space using the arrow keys when the cursor is on a control labeled Channel Space.
+You can also Go to user other users directly. To do this, select the Approach option from the context menu or press CTRL+G in the list of users, after selecting the desired person.
+## Push to talk function
+If you do not want to be heard all the time, you can activate the Push to talk function. This is a key or several keys that, when held down, make you heard in a conference and when released will automatically mute your microphone.
+Push to talk also works when the Elten window is minimised.
+
+# Other
+## Spell Check
+To check the spelling in any text field before you send/approve/save it, simply press Ctrl+Shift+S or select the appropriate option from the context menu; a list of errors found will be displayed with the option to correct them.
+NOTE!
+Premium feature, available in the Scribe package.
+## Generating alternative login codes
+If you have two-step verification enabled, every time you want to log in to a new device, you will be asked for a code, sent in an SMS message.
+However, there may be times when you are temporarily unable to access your phone.
+The alternative codes generated in the section Community/Manage My Account/Account Security/Manage Two-Factor Authentication/Generate backup Codes will be useful in such circumstances.
+Once selected, you will see a text box with the codes that you can copy and save in a safe place in case you need to use them.
+## Calling a user
+If the user is online, you can call him. He can either answer or reject the call. If he answers, a special conversation space is created for you, similar to a channel in conferences, but no one but you can join it.
+Under Community/Manage my account/Privacy you can set who can call you.
+## New window - Administration and Authors
+Once you are in Community/Users/Administration and Authors you can see Elten's development staff by function - translators, programmers, administrators, moderators, sponsors etc.
+## Manage My Account
+The account settings window, located in the Community menu, has been rebuilt - now the settings are divided into categories, just like the program settings. In this section you can edit your profile, change your status and signature, write your visitingcard, manage known languages, account privacy and security, personalise What's New notifications and manage premium packages.
+## Media
+In version 2.4, the player field and media such as audio posts on blogs and voice posts on forums has been unified so that it looks similar everywhere, making it easier to navigate.
+## Playback speed and tempo
+When in the player, press shift+up/down arrows or ctrl+up/down arrows to adjust the playback speed and tempo.
+## Do Not Disturb Mode
+If you're busy and don't want to be distracted by notifications, turn on Do Not Disturb mode, similar to what you're familiar with from IOS and Android. When it's active, you'll only see notifications in the What's New section, but sounds and voice information will not be presented. By default, this feature can be invoked with the keyboard shortcut SHIFT+F2. Once enabled, it will remain active until you manually turn it off or close the program.
+
+# Where are these functions?
+## Avatars
+Due to copyright issues and the low popularity of this feature, as of version 2.4 avatars have been removed from the program. This means that avatars will not be visible in the user's business cards and you will not be able to set them up or listen to them.
+Their role has been partly taken over by audio blog posts.
+## Chat
+The Chat function is no longer in the Community menu. Due to its low popularity in its previous form, this feature has been removed, but moved to Voice Conferencing, where you can text within a channel.
+## Files
+From now on, you can view your files in a separate program that you launch from within Elten. You can download it in the Programs section.
+All the features you remember from previous versions have been retained or improved.
+## Playlist
+The function to create and play playlists is no longer available in the main Elten program. To use playlists, download a program for this in the Programs section.
+NOTE!
+Shortcuts to play playlists are available as Quick Actions.
+## Youtube
+From now on Youtube is a separate program that we run within Elten. We can download and install it in the Programs section. Its look and functionality have been slightly revamped to make it easier to navigate and play videos. One of the many new features is the ability to download videos under your own name and in different formats.
+
+# Acknowledgements, from the author
+I'd like to take this opportunity to thank all the people involved in the development of version 2.4. Thanks to them, you can now enjoy all the new features mentioned above.
+It would be impossible to list all the people involved. First of all, however, I would like to thank:
+* User railwayguy - for running the English beta tests,
+* All the translators: hozosch, electro, Julitka, zvonimirek222, david, monstricek and Kumandan,
+* The testers, led by the most active users hozosch, thespyde, balteam, Julitka and daszekmdn,
+* The people who worked on the documentation, namely users Julitka and Paulinux for the preparation of the above document and users papierek and balteam for the preparation of the readme,
+* The main contributors Lowca_Androidow, Paulinux, daszekmdn, tomecki and Julitka,
+* And all those who were directly or indirectly involved in the development and shape of this product, who supported me and the whole staff in difficult moments and so eagerly filled in the Red Book of Endangered Bugs.
+Thank you!

--- a/locale/ja-JP/privacypolicy.md
+++ b/locale/ja-JP/privacypolicy.md
@@ -1,0 +1,39 @@
+# Privacy Policy of the EltenLink portal
+This document provides a detailed description of the data collected by the EltenLink portal and how it is used by the administration.
+Should you have any questions or concerns, please contact the administration directly through the portal or by e-mail
+support@elten.link
+
+## The data collected are:
+### Log files and security backups
+As part of the scope of maintenance of services related to the EltenLink portal, server event logs and security backups are collected.
+The event logs allow us to reproduce errors and problems related to the operation of the services, to protect EltenLink against hacking attacks and similar incidents. They do not contain any private data, in particular passwords or content posted on Elten, but only basic information about the operation of the services (protocols used, web browser or client version, IP address, ID of the service they refer to).
+Security backups are used in case of server failure. They contain a detailed record of the database allowing the portal to be restored in the event of a failure. All backup copies placed outside the portal server, especially in external cloud services, are encrypted.
+### User data
+The only private information required by the EltenLink portal is an e-mail address. No personal information (such as name) is required for registration.
+Users within the EltenLink portal can complete their profile by providing data such as:
+* first and last name
+* gender
+* date of birth
+* place of residence
+However, these profiles are filled out voluntarily and are not collected during the registration process. Users can hide the profile from people outside of their contact list, and delete this information at any time.
+As an additional layer of security, users can activate two-factor authentication, which uses the mobile phone number in the process of logging into the portal, sending the verification code by SMS message on the first such attempt from a new device. This is an optional functionality. The phone numbers collected in this way are not used for any purpose unrelated to two-factor authentication.
+In the above process, the mobile number data is transmitted via the Simple Notification Service to Amazon.
+### Other
+Other data collected by EltenLink includes only that provided by users within the platform. EltenLink does not collect any statistics from third parties.
+### Cookies Policy
+The EltenLink portal does not use cookies with the exception of the automatic login service.
+## Ways of using data
+### By administration
+Data collected by the administration and moderation of the portal is related to the need to maintain order, which includes the identification of users posting inappropriate content on the forums, so-called spam, insulting others or otherwise violating the terms of use.
+The data processed includes the IP address, computer ID and other personally identifiable information.
+### By newsletter
+The so-called Newsletter, i.e. information on news, warnings and other administrative notifications relating to the operation of the EltenLink website, may be sent to the e-mail address used during registration.
+### By other parties
+EltenLink does not pass on the data it collects to any other entities.
+It does not use third-party analytical tools or advertising services.
+## Data not processed by the administration
+The portal administration does not process, read or review sensitive data posted on the portal (with the exception of those posted above), in particular private messages and notes.
+The EltenLink portal does not collect any activity that is not necessary for its operation, i.e. any actions performed by the user locally.
+## Deletion of data
+All personal data, in particular the user profile, can be deleted by using the appropriate options. In case of any problems, please contact the administration.
+Data necessary for the operation of the service will not be deleted: forum posts, IP addresses, usernames.

--- a/locale/ja-JP/readme.md
+++ b/locale/ja-JP/readme.md
@@ -1,0 +1,247 @@
+# Introduction
+This document describes the features of Elten - the client of the EltenLink portal for Windows, which is used by blind people to communicate. The program allows you to send private and group messages, discuss in text and voice forums, write blogs with the possibility to create audio posts, create voice calls and much more.
+## Basic keyboard
+You navigate through the app primarily using the alt key, arrow keys, and tab key, just as you would in Windows. The alt key opens the main menu, which you navigate with the left-right arrows, expand with the down arrow or enter, and select the option you want with the enter key.
+In many places in the program, we can also use the context menu, which often gives us access to actions specific to a given element. The context menu can be opened by pressing the context menu key or by default with the shift+f10 shortcut, but it may also be the first item in the main menu when the alt key is pressed, if this has been set in the settings.
+Where you play media, the spacebar stops playback, the left/right arrows scroll, and the up/down arrows change the volume.
+Pressing F1 (the default) reads all the additional keyboard shortcuts of the currently selected control.
+## Quick Actions
+On the main screen of the application we also have access to so called quick actions, which allow us to easily get to any place in the program. Quick actions can be assigned to keyboard shortcuts, as well as hidden or deleted.
+You can also add to quick actions any group, conversation, the most interesting blog and so on.
+Note: If you remove any item from quick actions, you will also remove its shortcut. To leave the shortcut, instead of deleting it, select hide this action.
+## Add-on for nvda
+If you are using nvda, Elten will ask you to install an add-on. It improves Elten's interaction with NVDA, allows text scrolling or braille support, and allows you to use the same shortcuts you use in NVDA, such as Insert+A to read text.
+
+# Community
+The Community menu contains functions for communication between Elten users, the most important of which are messages, voice conferencing, blogs and a forum.
+## Messages
+In the Messages section you can send voice and text messages. In addition, the program allows you to create a group conversation for a group of friends.
+By default, recorded voice messages can be no longer than 2 minutes.
+After buying the audiophile package this limit is lifted.
+You can also send attachments in your messages (up to 4 MB by default). After subscribing to the courier package, this limit is increased to 32 MB and you will be able to add polls to your messages.
+This section also allows you to receive and send e-mails, it gives us some interesting possibilities, for example you can easily use mailing lists, register accounts in different services with your Elten e-mail address and most of all - you can easily e-mail other people.
+Each user has his own e-mail address, which consists of a user name and the domain Elten.me, e.g. john@Elten.me.
+To create an e-mail message, go to the Messages section, select create new message, then in the Recipient field, enter the e-mail address of the person to whom you want to send the message.
+## Blogs
+Blogs are one of the most used functions of Elten. They make it very easy to create and manage blogs and to view and comment on the work of others.
+Currently there are hundreds of blogs on Elten, with a variety of content ranging from cooking, gaming, philosophy, fiction, and differential equations. You can find just about anything here, and it's up to you what you choose. 
+This feature lets you create both text and audio content.
+You can browse blogs by the following categories:
+Managed blogs - our own blogs,
+Recently updated blogs - a list of blogs in chronological order; blogs with the most recent posts are at the top. If you are planning to run a blog, regular posting will definitely affect its popularity,
+Frequently updated - the name speaks for itself,
+Followed blogs - blogs that we follow; we get notifications whenever a new post is posted.
+Elten also allows us to view those blogs that are popular among the users we have added to our contacts.
+Moreover, after subscribing to the Scribe package, it is possible to follow specific posts, thanks to which we will receive information each time a new comment is posted on them.
+This is done using the Followed posts category.
+### Creating your own blog
+Each user can create one blog in the free version, and once you have purchased the "scribe" package, you have the chance to create an unlimited number of unique blogs, including blogs shared with other users.
+The blogs run on the wordpress system, so you can use many of the plugins available in this system. In addition, thanks to this we have access to a large number of features that allow us to take care of the appearance of our blog.
+If you are worried that you cannot share your blog with your friends outside Elten, nothing simpler - just copy the link to your blog or to a particular post and send it to any person or share it e.g. on Facebook.
+To create your own blog, simply go to Managed Blogs, then use the CTRL+N shortcut, enter a name and press enter.
+After pressing enter on a newly created blog, you may use the CTRL+N shortcut to add new categories or, after entering a given category or All Posts, to add new posts.
+When creating a new post, we can choose options such as the type of editor, the visibility of the post - for all or only for our friends, and we can allow or disallow commenting on it.
+We can also add tags to an post by pressing the familiar CTRL+N shortcut on the tags section under the tab.
+### Customising your blog
+If you press CTRL+E on one of your managed blogs or select the relevant option from the context menu, you will be shown the options for that blog.
+In the General section, we can set such things as its name, description, language or mark it as public.
+Public blogs are searchable in search engines such as Google and others, unchecking this box should, although not in every case, prohibit search engines from showing this blog in search results.
+In the Comments section, we can set who can comment on our posts and whether comments need to be approved, and enable automatic blocking of comments after a certain time.
+We can also set how comments should be sorted on the site.
+In the Posts section, there are various options for personalising the display of your posts in the browser.
+In the Date and Time section, we can set the format and time zone of the blog.
+In the Other section we can manage our wordpress account, blog tags and its domain. Here we can also find pending comments for approval.
+### Viewing external wordpress blogs
+This is a powerful feature, making it much easier to browse blogs running on wordpress. When you open a blog, Elten can display posts from all categories on that blog, but it is also possible to browse individual categories. This way, no time is wasted on graphics and ads present on the page are skipped.
+To check if a blog is supported, enter its URL under "open external wordpress blog".
+## Forum
+Forum is a place where you can talk about various topics. To make it easier to find interesting content, it has been divided into groups.
+Additionally, at the bottom of the forum you will find such tabs as Recently Active Groups, Recommended Groups, Open Groups or All Groups.
+Each user can create their own groups.
+#### Recommended groups
+These are the most popular groups on Elten, they are the backbone of the forum. 
+#### Public groups
+These are groups which usually deal with more specific topics. If you have a passion, if you know more about a topic than anyone else or if you just want to see what it is like to manage a group, there is nothing to stop you from creating a group.
+It is worth noting that even if someone does not belong to a public group, they can still browse its forums.
+The group administrator can determine whether anyone can join the group or whether a request to join must be approved by the administrator or moderators.
+A public group has a chance of becoming recommended if it proves interesting enough for a large part of the community.
+#### Hidden groups
+This type of group can only be joined by an invitation from an administrator or moderator. The group is not publicly visible and uninvited people cannot browse its forums. This group can be used to discuss more sensitive topics or simply to chat with friends.
+### Keyboard Shortcuts
+To help you search for content in the forum, the most important shortcuts are listed below:
+CTRL+, (comma) - go to the first post in the thread,
+CTRL+. (dot) - go to the last post in the thread,
+CTRL+u - go to the first unread post in the thread,
+Shift+Enter - show all threads in a group
+Shift+Left/Right arrows - allow you to set what you want to read first when navigating groups, forums or threads. For example, you can set Elten to inform you before the name of each group about the number of unread posts, and then the name of the group you are on.
+Shift +Up/Down arrow - allows you to browse the threads in a given group by tags. Tags are a set of keywords that make it easier to quickly find the right thread, for example, some threads may be tagged "closed" or "resolved". If you select the "resolved" tag, navigating with the up and down arrows alone, you will only come across threads which are tagged with this tag.
+### Useful features in the forum
+To make it easier to browse content, we can follow forums or threads that interest us. To do this, you must, while standing with the cursor on a given section in a group, enter the context menu and add the forum you are interested in to the followed forums, and if you want to follow a thread, then, while standing on the thread, enter the context menu and select Add to followed threads.
+Please note that in order to monitor entire forums in groups of which we are not moderators or administrators, we must have purchased the Courier package.
+In addition, we may mark a thread which we have not read, e.g. because it has several hundred posts, for reading later; to do this, use the arrows to find the appropriate thread, and then select Mark thread from the context menu. Instead of entering the context menu, we can simply press CTRL+H.
+The list of marked threads can be found at the top of the forum, in the Marked Threads tab.
+Please note that marking threads is only possible after purchasing the Elten premium courier package.
+If you don't have time to finish reading a thread, you can use bookmarks; to do this, on the post you've finished reading, go to the context menu, then use enter to select navigation, then bookmarks; on the list that appears, go to the context menu and click New Bookmark.
+You can also create a bookmark using the shortcut combination - CTRL+B (to enter bookmarks) and CTRL+N.
+Creating bookmarks is possible after buying the Courier package.
+The same package allows you to hide signatures of other users. To do this simply use the context menu on any post and use the down arrow to find the Hide signatures option.
+### Mentions
+Mention messages are short messages with an automatic link to the relevant post. If you see a post which you know your friend may be interested in, you will add a link to this post and, if appropriate, a short note stating why you are referring to this particular post.
+After opening the mention, the recipient will be automatically transferred to the relevant post.
+After subscribing to the courier package, it is also possible to reply to mentions and view the history of mentions.
+## conferences
+This module allows you to conduct voice conferences with other users of the program, similar to applications such as teamtalk or discord. It is also possible to watch movies and listen to music together.
+Thanks to support for two sound cards, you can also host podcasts or present games. The latter function is only available to users who have subscribed to the audiophile package.
+### Create your own channel
+Once you've entered the conference, you'll see a list of channels. To join any channel, move the up and down arrows and press enter or CTRL+J on the channel you're interested in, if any are available. To create a new channel, press CTRL+N or select new channel from the context menu.
+If you're not an advanced user and just want to chat with your friends, you can safely leave all the default values, just type in the channel name, then tab to find create a channel and press enter. The default settings are more than sufficient for this.
+Channel name - this is where you enter the name under which your room will be visible.
+Language - select the language in which the conversations on the channel will take place. It is possible to filter channels by language.
+Bitrate - the higher the bitrate, the better the quality, but also the higher the data consumption; increasing the bitrate is not recommended for weak internet connections.
+Frame size - the larger the frame, the better the quality and lower data consumption, but higher latency.
+Channels - here we can choose whether our channel is to be stereo or mono.
+Space virtualisation - with the panning setting when moving on the channel board, the users position will only change from left to right, and with the hrtf setting we will be able to walk in 3d, i.e. when moving we will be able to hear the callers from the left, right, front and back (see below).
+Note: premium users who have purchased the audiophile package will be able to select the room size and background sounds for the hrtf channel.
+Set password for this channel - if you check this box and enter the password, no one who does not know the password will get into the channel; do not give the password to people you do not want in the channel.
+### Channel space
+When you create your own channel or join an existing one, the first thing your cursor will stand on is the channel space. 
+Let's imagine that our channel is a room with other callers in it. By default, we're all standing in the same place. 
+Using the left, right, up and down arrows, we can move around this virtual space.
+When we set the virtual space to panning when creating a channel, the left-right arrows move us left or right relative to other users, and the up and down arrows change their volume. The further away we stand from someone, the greater the volume differences are.
+When space virtualisation is set to hrtf, we will hear other callers from different directions; if we move away from them, we will hear them more quietly.
+### List of channel users.
+Press the tab key once to get to the list of channel users. Use the up and down arrows to navigate through the list as usual.
+If you open the context menu on a user, you will see options such as changing the volume or muting the user.
+It is also possible to whisper to other users, so that other people in the channel will not hear it. To do this, hold down the space bar while speaking to the person you want to whisper to; releasing the space bar means the whisper ends.
+Use the CTRL+G shortcut to approach another user, provided they have previously changed their position on the channel board. By pressing this shortcut on yourself, you can find yourself at the start position in the space.
+### Chat.
+You can also write text messages in the channel. The first field, Chat history, allows us to view recent messages. 
+Note that the history for events before you joined the channel is not visible to you. When you leave the channel, the history is not saved.
+We can enter our message in the chat field. You can send it by pressing enter.
+### objects and streaming
+When you press enter on the Objects and streaming option, a menu appears where you have a choice of options:
+*Channel objects - if we want to add variety to our conference, we have this option. With objects; we can add forest, mountain or sea sounds.
+If you create a large channel, you can place sounds in different places to add variety to the channel space. For example, place a clock in the bottom corner, bar sounds in the middle and city sounds in the top right corner.
+*Sound card streaming - with this option, you can stream movies, songs, whatever you want to your channel.
+*Stream audio file - if you want to play a file from your computer to your conference participants, you can easily do it with this option; click enter, select the file from your computer and from now on, everyone in the channel can hear what you want to present to them.
+### change volume
+By pressing enter on the Change Volume option, you can manage the volume of your microphone, the main volume, i.e. how you hear everyone in the conversation, and the volume of the stream.
+Use the up and down arrows to adjust the volume, and use the tab to move between volume types.
+### Status
+Here we can check how much time we have spent on the channel, what latency we have, and how much data we have sent and received. The latter is particularly useful if you have a limited internet package.
+To check your latency, turn on the listen on yourself.
+### Push To Talk
+If you only want to be heard when you hold down the corresponding key, then simply select this option.
+If you check the box, you can use the tab key to set which key you want your microphone to activate when you press it. You can choose from shift, alt or CTRL as well as letter and number keys. You can select more than one key.
+### Save this conference to file
+This function allows you to record what is happening on your channel. If you want to have the recording of the conference in one file, then select save the mix of streams to one file.
+There is also an option added experimentally, Keep separate streams, which allows you to save each user from the channel in a separate file.
+### Calling other users.
+When you don't feel like creating a channel but want to talk to someone, you can call them. To do this, simply select someone from your contact list and choose Call from the context menu.
+## Notes
+Elten allows you to create your note and share it with other people, for example to edit the text together later.
+## Polls
+Polls are a simple tool that allows Elten users to see what other users think about various topics. They are also used to find out how Elten members feel about, for example, new features in Elten. Group administrators can use them to get answers to questions relevant to their group.
+Polls can be used by anyone and everyone can create them without limitation, and what you ask is up to you.
+It's worth noting that polls can also be added to forum posts so that users can access them more easily.
+Elten allows you to filter the responses in your polls. For example, let's imagine that someone created a poll about cooking. In the first question he asked if we like to cook. Thanks to the filtering option you can see how the following questions were answered by people who like to cook and those who are not fond of this activity.
+To use the filters, select a specific poll and then the Show Results option. Use the up and down arrows to move between questions; when you press tab on a question, you will see the answers below the arrows.
+On each answer, after pressing the context menu, two options appear: Filter with this answer and Filter without this answer. If the question has 3 answers and we choose Filter without this answer on the first of the three options, it will not be taken into account. That is, if out of 9 people, 3 voted for hypothetical answers A, B and C, each answer has 33% of the vote; after filtering out answer A, the first one has 0%, the other two have 50%. From now on, people from answer A will not be considered for other questions.
+## Users
+Here you will find information about the accounts of Elten users.
+### Contact list
+The people you have added to your contacts can be found here.
+### Other options
+Further down the menu you can, for example, find out who is currently online, the list of recently registered users on Elten or the most recently active users.
+In addition, you will find the Elder Council, which is made up of users who have had a significant impact on Elten's development.
+## Manage my account
+Here you will find all the settings related to your account.
+### Profile
+Here you can enter some information about yourself, such as your age or gender, which will be visible in your visitingcard to other users.
+### Visitingcard
+If you would like to write something about yourself and encourage other users to write to you, this is a good place for it.
+### Languages
+Elten has various language filters.  This prevents groups, blogs and voice conference channels, for example, from displaying in languages you don't speak.
+### Status and signature
+Status and signature can be used to enter a short sentence or quote that is important to you.
+Status is displayed after our user name in the contact list, for example, whereas a signature is displayed below our forum entries.
+### What's new Notifications
+Here you can specify what news you would like to be notified of by Elten.
+### privacy
+You can adjust, for example, who (all Elten users or just your friends) should see your profile. In addition, you can set a setting so that only people you have in your contacts can call you.
+### security
+This section allows you to change your email address, password or set up two-factor authentication.
+Two-factor authentication significantly increases the security of your account. Every time you log on to Elten, you will have to enter your password and a received sms code.
+### Other
+Under this tab you can purchase premium packages to support the Elten project.
+
+# programs
+Programs section contains additional packages to extend Elten's capabilities. We can add and remove them as needed. This section of the document will describe some of them.
+## File Manager
+This program allows us to browse the disk of our computer. We can use it instead of Windows explorer. You can use it to open audio, .html or text files (including .doc, .txt, .rtf, .pdf - after installing the appropriate package).
+It is also possible to convert text files into voice files, read by a synthesizer, after installing the Speech Outputter program.
+The manager can be used as a player for many popular audio formats such as mp3, Wave, OGG, Wma, flac or opus.
+It is worth noting that thanks to the manager we can open files located e.g. in folders of applications such as Dropbox or Google Drive on the computer.
+## Youtube.
+With this program we can watch videos from youtube and download them to disk. Files can be automatically converted to popular audio formats. However, it is not possible to read comments under the video, log into your google account or subscribe to channels.
+## Playlist
+Installing this program allows us to create and manage playlists; after adding the appropriate shortcuts to Quick Actions, we can play them from anywhere in the program.
+
+# Tools
+In the tools section we can change the program settings, use functions such as checking the Internet connection or debugger.
+## Program settings.
+You can navigate through the settings using the up and down arrows to select a category. After selecting the section you are interested in, you can access its settings by pressing the tab.
+### General
+Language - here you can set the main language of the program interface.
+Note that this only applies to the interface, not to group filters or conference channels.
+Automatically minimize Elten Window to system tray - Elten will be minimized when you switch to another window. You can restore it later from the tray using CTRL+Alt+Shift+T combination.
+Enable auto-login - if this checkbox is selected, Elten will log in automatically every time it starts, without the need for a login or password. It is not recommended to set this option if you are not the only user of the computer.
+Automatically start Elten after I log on to Windows - the program starts automatically with Windows.
+The next option allows you to check for updates each time you start the program. If a stable version is available, an update will be shown and, if approved, will be downloaded.
+Send Elten usage reports - Elten will send basic information such as your computer system and processor to the program developer.
+### Interface
+First of all, there is a checkbox which allows you to hear the sound of a set sound theme. The next field is responsible for its volume. Then you can select the sound theme itself.
+If you press the Tab key again, you will find yourself in the Manage sound themes option, where you can download and delete sound themes. 
+Note! By subscribing to the audiophile package, it is possible to download all sound themes available on the Elten server.
+The next checkbox is the positioning of the interface sounds in space; when moving through menus or lists, the sound moves from left to right as you move through the items. Unchecking this box causes all interface sounds to be heard in the middle.
+The next field allows us to disable or enable background sounds (e.g. in menus) and dialog sounds.
+Show context menu in the menu bar - context menu, available under the context menu key or Shift+F10, will additionally be displayed as the first tile of the main menu, under the Alt key.
+Announcement about types of controls - here we can choose whether we are to be informed about the type of control by voice, sound, or perhaps by voice and sound. The type of control is for example a checkbox, button, edit field, etc.
+Another checkbox specifies whether lines are to be wrapped in text fields
+Display method of selection lists - determines whether, when the down arrow reaches the end of the list, the cursor should stop, or, in the circular variant, should move back to the beginning of the list.
+Round up the forms - a similar option, but applies to moving the focus around forms; when selected, the focus will move around them.
+### Voice.
+In this category, we can choose whether Elten should use nvda, as a screen reader, or a sapi 5 synthesizer of our choice. We can also choose the typing echo, which is what Elten should read out to us when we type characters and words.
+There is also a checkbox for enabling braille support. Only works with nvda and requires the add-on installed
+Note that this feature can cause problems with very long text fields; it is recommended that you disable it if you have problems.
+### Clock
+By default, Elten informs you of full hours with a sound and a voice. Here you can set whether this should be a sound, a sound together with voice information or no information at all. You can also change the frequency at which you are informed of the current time; you can choose between hourly, half-hourly and 15-minutely notifications.
+In addition, we can allow Elten to "wake" us up at a time of our choosing by adding our own alarms.
+### Audio devices.
+Output device - here we select the sound card through which Elten should send sound.
+Microphone - as the name suggests, here we select the sound card through which Elten will record sound, for example in voice conferences, forums or voice messages.
+The next checkbox allows you to enable or disable fx effects.
+Next, we can choose whether noise reduction should be enabled for conferences, conferences and forums or not at all. Noise reduction is very useful if your computer's fans make a loud noise or your microphone simply hums.
+We can also enable/disable echo cancellation. This feature allows you to avoid so-called feedback, commonly known as crossover when headphones are disconnected.
+
+# Help
+In this section you will find things like the program's license, Read Me (this document), the audio theme's sound guide or the changelog.
+Don't forget to read the license!
+If you have any other questions not covered in this document and the entire help section, feel free to ask them in the Elten forum.
+
+# Premium packages
+In several places you will see information about paid packages to purchase. Up to time summary of the benefits of buying each package can be found in Community, Manage My Account, Others, Premium Packages menu.
+
+# License assumptions
+Elten is based on the GNU GPL 3 - General Public License. This means that it is open source software, i.e. it has open source code.
+The purpose of the GNU GPL is to give users four fundamental freedoms
+* the freedom to run the program for any purpose 
+* the freedom to study how the program works and adapt it to your needs 
+* the freedom to redistribute an unmodified copy of the program 
+* the freedom to improve the program and distribute your own improvements to the public, so the whole community can benefit from them. 
+For more information on licensing, visit the link:
+http://www.gnu.org/licenses/quick-guide-gplv3.html
+
+# Credits
+Information about the authors of the program can be obtained from the appropriate section of the Users menu.
+This document was written by users balteam and papierek.

--- a/locale/ja-JP/rules.md
+++ b/locale/ja-JP/rules.md
@@ -1,0 +1,128 @@
+EltenLink Terms and Conditions
+
+# I. Concepts and definitions
+1. "Portal" refers to all content within the EltenLink domain and all functionalities related to it.
+2. EltenLink "Developer" is Dawid Pieper.
+3. "User" refers to any person registered and using the Portal to publish any content.
+4. "Council of Elders" is formed by the users who are part of the council that determines the shape of the portal, its future and policy.
+The Council of Elders is chaired by Developer.
+5. "Group Administrator" is the person who is the founder of the group (unless these privileges have been delegated to another person) and is responsible for its form.
+Group administrators report directly to the Council of Elders, unless this document provides otherwise.
+Each group has exactly one administrator.
+6. "Group Moderator" is the person who reports to its administrator and carries out the duties assigned by him.
+7. The administrator and all moderators of a group are considered "Group Moderation".
+8. "Language community" is defined as groups marked as recommended, in which discussions are held in a given language.
+9. A "community group" is the main group of a given language community, designated as a recommended group and containing the name of the community concerned.
+10. "Management Unit" is defined as the users who are in charge of the community of a particular language.
+Administrators of all groups recommended in a given language are subordinate to the Management Unit of such language, while the Management Unit is subordinate directly to the "Council of Elders".
+11. The "Manager of the Management Unit" is the administrator of the community group appropriate for the unit.
+12. "Administration of the Portal" is constituted by the "Council of Elders" and all "Management Units".
+13. "Spammer" is a person who posts content on the Portal that is inappropriate to the discussions, duplicates, harms the Portal or in any way offends users of the Portal, their beliefs, religion and views, as well as any national, religious or ethnic groups.
+14. 'Forum' means any forum that is part of the Portal and belongs to any group of the Portal. A forum also includes all polls and attachments placed on it.
+15. "Ban" is a temporary or permanent restriction of the user's access to the portal, his account or the group, constituting a punishment for violating these rules or the group's internal rules.
+The decision to impose or revoke such a ban is taken by the members of the Council of Elders (globally) or the group's moderation (to the extent limited to the group concerned).
+
+# II. Users
+1. Anyone over 13 years of age can become a User.
+2. The usage of multiple accounts is prohibited.
+Exceptions are cases where the Council of Elders has given its consent to the creation of a second or subsequent account by the user in individual cases.
+3. The login (nickname) of the portal user may not contain content considered offensive.
+4. In order to register, it is required to provide an e-mail address to which the user has permanent access and update it if necessary.
+In special cases, it may be used to verify the identity of the user.
+5. In the event of a hacking into someone else's account, the Council of Elders shall, at the request of the injured party, forward the notification of the crime to the law enforcement authority of the country of the user committing such activity.
+Information about burglaries or attacks on a wider scale is always forwarded to the Polish Office for Personal Data Protection.
+6. In the case of violation of personal rights of a private person or organization by a user of the portal within the scope specified by the law of the user's residence, at the request of the injured party, the Council of Elders may secure evidence and submit a notification of the crime to the law enforcement authorities.
+7. Users may receive access to the reserved functions (premium), available as a reward for supporting the project.
+
+# III. Portal administration
+1. Members of the Council of Elders and managers of the Management Units are appointed and dismissed by the author.
+2. The Manager of the Management Unit has the right to appoint further members at his discretion.
+3. Membership in the Portal Administration does not release from the obligation to comply with these Regulations.
+4. The membership in the Portal Administration automatically expires as a result of:
+A. Death of the user or his loss of ability to continue performing the function entrusted to him,
+B. Unannounced user inactivity for more than 30 days, except in justified random cases,
+C. Global user banning.
+5. The Council of Elders is competent to:
+A. Coordinating the rules and arrangements between the Management Units of different communities,
+B. Global user banning,
+C. Supervision over non-recommended groups in terms of compliance with the principles of these regulations,
+D. Taking care of the promotion of the portal and performing representative functions on its behalf,
+E. Granting power of attorney to represent the Portal,
+F. Resolving disputes not covered by these Rules.
+6. It is prohibited to abuse the rights resulting from the membership in the Portal Administration.
+
+# IV. Blogs, private messages and notes
+1. The content placed on blogs, private messages and notes are not subject to moderation except for the points of these rules, and the user who publishes them remains responsible for them.
+2. The user may be punished by banning and/or removing the published content in special cases, when:
+A. They infringe the copyright, property rights, distribution rights belonging to private persons or organisations or the rights applicable depending on the country of residence of the user,
+B. They are offensive to other users (in favour of requesting the deletion of these materials by the interested party to the Council of Elders).
+3. No harmful material or potentially unwanted software may be shared.
+If such material is detected by antivirus software on the server, it will be automatically deleted.
+4. Developer reserves the right to set limits of disk space that can be occupied by a single user.
+5. Materials made available in the form of private messages, blog posts or notes cannot constitute regulations or attachments to group regulations.
+
+# V. Forum
+1. Each user has the right to speak in the forum without any restrictions as to the points of these rules, internal regulations and laws of the country of residence. No other user may forbid it or otherwise prevent it.
+An exception to this are restrictions imposed by the group moderation and the Portal Administration, resulting from the violation of any of the points of this document or the rules of the group concerned.
+2. Each user speaking on the forum is obliged to ensure that his statement is understandable and legible, in particular by observing the rules of spelling and grammar of a given language, avoiding the mixing of topics, creating threads in relevant sections and giving them appropriate titles.
+3. The moderation of the group to which the forum belongs is responsible for maintaining order in the forum. It has the right to:
+A. Delete threads or posts,
+B. Transfer posts and threads between threads, forums and groups,
+C. Edit posts and/or thread titles,
+D. Bann the user in the group in which the offence was committed,
+E. Call to the Council of Elders for a global ban on the user.
+4. Forum post can be edited or deleted by moderation in case of:
+A. Disclosing private or sensitive data of other people without their consent (at the request of the injured person),
+B. Explicit offense to the portal user, other person or institution,
+C. Clear inconsistency or non-compliance with the subject matter of the discussion,
+D. The necessity to adjust the post to the template or the nature of the thread,
+E. Infringement of other rights under these rules or the internal rules of the group in which the post was made.
+5. By posting a given content on the forum, the users declare that they have the right to publish it. It is prohibited to post content that violates copyright or related rights.
+Group Moderation is obliged to remove such content immediately.
+
+# VI. Non-community groups
+1. Groups that are not community groups are divided into:
+A. Recommended groups, which are separated from the social group of a given language,
+B. Public groups, user-generated and publicly visible,
+C. Hidden groups, created by users and visible only to their members.
+2. Group administrators remain autonomous in the areas of:
+A. Establishing internal regulations, subject to public disclosure,
+B. Establishing internal moderation rules, joining and posting conditions,
+C. Banning or kicking aut of the group in the compliance with internal rules.
+3. The group regulations cannot be inconsistent with this document.
+4. The group regulations should contain information about:
+A. The supremacy of these regulations,
+B. Anticipated penalties,
+C. If warnings are taken into account, the way of warning users,
+D. The way of informing about changes in the threads,
+E. Any other group policy.
+5. A public group in which 1,000 published posts are exceeded and which has at least 15 members shall submit its rules of procedure within 14 days of reaching this limit.
+If the group fails to submit its rules of procedure within the specified time, the Council of Elders has the right to appoint a new administrator for the group in accordance with point 7.
+6. The Council of Elders may appoint a new administrator for the group in the event of:
+A. Death of the administrator or his incapacity to continue to perform this function,
+B. Unannounced inactivity of the administrator for more than 30 days,
+C. Breaches of these rules by the administrator,
+D. Submit a reasoned request to change the administrator of a public group which has reached at least 15 members and 1,000 posts, from at least 51 percent of the users who have been active in the group in the last 30 days and who have belonged to the group for at least 90 days.
+7. The election of a new administrator following a change of administrator by the Council of Elders is done by voting for a new candidate from the list of the most active members of the group, at least three.
+8. Recommended groups are a separate, subordinate part of the community group of a given language with their own forums, moderation and regulations.
+8.1. The provisions of the regulations of the recommended groups must be consistent with the regulations of the community group from which the group is separated and with these regulations.
+8.2. The administrator of a recommended group may be appointed or dismissed at any time by the administrator of the community group from which the group is separated.
+8.3. A public group may be transformed into a recommended group with the agreement of the administrator of that group and the administrator of the social group to which the group will belong.
+8.4. The administrator of the recommended group is obliged to appoint at least one moderator.
+8.5. In the recommended group all bans of users from the social group are valid.
+The moderation of recommended groups may also impose internal bans concerning only a specific group.
+9. Recommended groups are intended to transfer popular topics from the community group. Two recommended groups with the same theme cannot be separated within a social group.
+Moderation of the recommended groups and community groups is required to take care of the correct transfer of threads between the groups.
+The transfer of threads can be performed directly on the basis of an agreement between the recommended groups, without the participation of the community group moderation.
+10. Developer reserves the right to set limits of disk space that can be occupied by a single group.
+
+# VII. Final provisions
+1. These regulations come into force on January 24, 2021.
+2. In case of failure to include a specific situation in these regulations, the decision on the harmfulness of the act considered is made by the Developer in consultation with the Council of Elders and/or the Management Unit.
+3. The user using the portal declares that he knows and understands these regulations.
+4. Each user has the right to report any content that is inconsistent with these regulations to the group moderator, its administrator, the Management Unit or the Council of Elders (in case of no reaction from subordinate units).
+5. Each user may report a doubt as to any point in these regulations.
+6. Questions and requests addressed to the Portal Administration should be written in English or the language used by the recipient. The Portal Administration reserves the right to ignore any requests that do not comply with this point.
+7. Users are obliged to treat with due respect the moderators of groups, their administrators, Management Units and Council of Elders, as the bodies managing the Portal.
+It is forbidden to aggressively question the decision of any of these units, to question their competence or to harass them because of their position.
+8. The Developer reserves the right to change or cancel these regulations at any time. Users will be informed about introduced modifications.


### PR DESCRIPTION
Pl: Rozpocząłem pracę nad japońskim tłumaczeniem Elten. Dokumentacja nie została jeszcze przetłumaczona, ponieważ chciałem najpierw udostępnić program.
Użyłem modelu Advanced Reasoning GPT firmy Open AI i modelu językowego nowej generacji DeepL do wykonania tego tłumaczenia, ponieważ nie jestem rodzimym użytkownikiem języka japońskiego, ani nie mówię płynnie. Wprowadziłem kilka poprawek tam, gdzie uznałem, że tłumaczenie tego wymaga, ale nie mogę zagwarantować doskonałej jakości. Uważam, że na razie jest wystarczająco dobre, ale z pewnością będzie wymagało poprawek. Chciałem jednak położyć podwaliny pod to, by ktoś później mógł kontynuować prawidłowe tłumaczenie Elten.
En: I have started working on a Japanese translation for Elten. The documentation is not yet translated, because I wanted to make the program accessible first.
I used Open AI's Advanced Reasoning GPT model and DeepL's next generation language model to make this translation, because I am not a native Japanese speaker, nor am I presently fluent. I have made some corrections where I felt the translation needed them, but I cannot guarantee perfect quality. I believe it is good enough for the time being, but it will definitely need to be revised. However, I wanted to lay down the groundwork for someone to come in later and continue translating Elten properly.
Jp: 現在、エルテンの日本語訳に取り組んでいます。 まだドキュメントは翻訳されていませんが、まずはプログラムにアクセスできるようにしたかったからです。
私は日本語のネイティブスピーカーではなく、また現在も流暢に話せるわけではないため、この翻訳にはOpen AIのAdvanced Reasoning GPTモデルとDeepLの次世代言語モデルを使用しました。 翻訳が必要だと感じた箇所はいくつか修正しましたが、完璧な品質を保証することはできません。当面はこれで十分だとは思いますが、間違いなく修正が必要でしょう。しかし、後から誰かが来て、きちんとエルテンの翻訳を継続できるよう、基礎を築いておきたかったのです。